### PR TITLE
Fix admin email in seed script

### DIFF
--- a/seed.py
+++ b/seed.py
@@ -19,12 +19,12 @@ with app.app_context():
 
     admin = User(
         name="Alexandre Stephen",
-        email="GestionVehiculeStomer.gmail.com",
+        email="GestionVehiculeStomer@gmail.com".lower(),
         role="admin",
     )
     admin.set_password("Sophieestaires59940")
     db.session.add(admin)
     db.session.commit()
     print(
-        "Init OK. Logins: chef@csp.local/chef123 adjoint@csp.local/adjoint123 dupont@csp.local/dupont123 admin: GestionVehiculeStomer.gmail.com/Sophieestaires59940"
+        "Init OK. Logins: chef@csp.local/chef123 adjoint@csp.local/adjoint123 dupont@csp.local/dupont123 admin: GestionVehiculeStomer@gmail.com/Sophieestaires59940"
     )


### PR DESCRIPTION
## Summary
- correct admin email address in `seed.py` and ensure lower-case storage

## Testing
- `python seed.py`
- `python - <<'PY'
from app import app, db, User
with app.app_context():
    u = User.query.filter_by(role="admin").first()
    print(u.email)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a61e0d20e48330a21ac94137cbbb29