### PR TITLE
Use LoginForm for unified login route

### DIFF
--- a/templates/first_login.html
+++ b/templates/first_login.html
@@ -55,7 +55,7 @@
       {% endfor %}
     </div>
     {{ form.submit(class_="btn btn-primary") }}
-    <a class="btn btn-link" href="/login_plain">J’ai déjà un compte</a>
+    <a class="btn btn-link" href="{{ url_for('login') }}">J’ai déjà un compte</a>
   </form>
 </body>
 </html>

--- a/templates/login_basic.html
+++ b/templates/login_basic.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block content %}
 <h1 class="h4">Connexion</h1>
-<form method="post" action="/login_plain">
+<form method="post" action="{{ url_for('login') }}">
   <div class="mb-3">
     <label for="email" class="form-label">Email</label>
     <input id="email" name="email" type="email" class="form-control" required>

--- a/templates/login_plain.html
+++ b/templates/login_plain.html
@@ -37,12 +37,13 @@
       {% if messages %}<ul class="flash">{% for c,m in messages %}<li>{{m}}</li>{% endfor %}</ul>{% endif %}
     {% endwith %}
 
-    <form method="post" action="{{ url_for('login_plain', **request.args) }}">
+    <form method="post" action="{{ url_for('login', **request.args) }}">
+      {{ form.csrf_token }}
       <label>Email
-        <input name="email" type="email" required>
+        {{ form.email(type="email", required=True) }}
       </label>
       <label>Mot de passe
-        <input name="password" type="password" required>
+        {{ form.password(type="password", required=True) }}
       </label>
       <button class="btn" type="submit">Se connecter</button>
     </form>


### PR DESCRIPTION
## Summary
- replace old login_plain redirection with real `/login` route using LoginForm
- render login_plain template with form fields and CSRF token
- adjust templates linking to the new route

## Testing
- `pytest`
- `python -m py_compile app.py && echo py_compile_success`


------
https://chatgpt.com/codex/tasks/task_e_68a6b999e1b48330aba5387be2611883