### PR TITLE
Define role constants and enable super admin promotion

### DIFF
--- a/models.py
+++ b/models.py
@@ -5,13 +5,21 @@ from werkzeug.security import generate_password_hash, check_password_hash
 db = SQLAlchemy()
 
 class User(db.Model):
+    ROLE_SUPERADMIN = "superadmin"
+    ROLE_ADMIN = "admin"
+    ROLE_USER = "user"
+
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(120), nullable=False)
     email = db.Column(db.String(120), unique=True, nullable=False)
-    role = db.Column(db.String(50), default="personnel")
+    role = db.Column(db.String(50), default=ROLE_USER)
     password_hash = db.Column(db.String(255), nullable=False)
-    def set_password(self, pwd): self.password_hash = generate_password_hash(pwd)
-    def check_password(self, pwd): return check_password_hash(self.password_hash, pwd)
+
+    def set_password(self, pwd):
+        self.password_hash = generate_password_hash(pwd)
+
+    def check_password(self, pwd):
+        return check_password_hash(self.password_hash, pwd)
 
 class Vehicle(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/seed.py
+++ b/seed.py
@@ -1,30 +1,35 @@
-
 from app import app, db, User
 from models import Vehicle
-with app.app_context():
-    db.drop_all(); db.create_all()
-    # vehicles
-    data=[("VL1","Véhicule Léger 1 (Chef de centre)",5),
-          ("VL2","Véhicule Léger 2 (Adjoint)",5),
-          ("VID2","Véhicule d'Instruction Dép 2",5),
-          ("VIDXL","Véhicule d'Instruction XL",7),
-          ("VRID","Véhicule Rapide d'Intervention Dép",5)]
-    for c,l,s in data:
-        db.session.add(Vehicle(code=c,label=l,seats=s))
-    # users
-    chef=User(name="Chef de centre", email="chef@csp.local", role="chef"); chef.set_password("chef123")
-    adj=User(name="Adjoint", email="adjoint@csp.local", role="adjoint"); adj.set_password("adjoint123")
-    per=User(name="Sapeur Dupont", email="dupont@csp.local", role="personnel"); per.set_password("dupont123")
-    db.session.add_all([chef,adj,per]); db.session.commit()
 
-    admin = User(
-        name="Alexandre Stephen",
-        email="GestionVehiculeStomer@gmail.com".lower(),
-        role="admin",
-    )
-    admin.set_password("Sophieestaires59940")
-    db.session.add(admin)
+
+with app.app_context():
+    db.drop_all()
+    db.create_all()
+
+    # vehicles
+    data = [
+        ("VL1", "Véhicule Léger 1 (Chef de centre)", 5),
+        ("VL2", "Véhicule Léger 2 (Adjoint)", 5),
+        ("VID2", "Véhicule d'Instruction Dép 2", 5),
+        ("VIDXL", "Véhicule d'Instruction XL", 7),
+        ("VRID", "Véhicule Rapide d'Intervention Dép", 5),
+    ]
+    for c, l, s in data:
+        db.session.add(Vehicle(code=c, label=l, seats=s))
+
+    # users
+    chef = User(name="Chef de centre", email="chef@csp.local", role=User.ROLE_ADMIN)
+    chef.set_password("chef123")
+    adj = User(name="Adjoint", email="adjoint@csp.local", role=User.ROLE_ADMIN)
+    adj.set_password("adjoint123")
+    per = User(name="Sapeur Dupont", email="dupont@csp.local", role=User.ROLE_USER)
+    per.set_password("dupont123")
+    super_admin = User(name="Super Admin", email="superadmin@csp.local", role=User.ROLE_SUPERADMIN)
+    super_admin.set_password("superadmin123")
+    db.session.add_all([chef, adj, per, super_admin])
     db.session.commit()
+
     print(
-        "Init OK. Logins: chef@csp.local/chef123 adjoint@csp.local/adjoint123 dupont@csp.local/dupont123 admin: GestionVehiculeStomer@gmail.com/Sophieestaires59940"
+        "Init OK. Logins: chef@csp.local/chef123 adjoint@csp.local/adjoint123 dupont@csp.local/dupont123 superadmin@csp.local/superadmin123"
     )
+

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -9,13 +9,13 @@
       <td>{{u.first_name or ""}}</td>
       <td>{{u.last_name or ""}}</td>
       <td>{{u.email}}</td>
-      <td><span class="badge bg-{{ 'primary' if u.role=='admin' else 'secondary' }}">{{u.role or 'user'}}</span></td>
+      <td><span class="badge bg-{{ 'primary' if u.role==ROLE_ADMIN else 'secondary' }}">{{u.role or 'user'}}</span></td>
       <td><span class="badge bg-{{ 'success' if (u.status or '')=='active' else 'warning' }}">{{u.status or 'n/a'}}</span></td>
       <td class="d-flex gap-2">
         {% if (u.status or '') != 'active' %}
           <a class="btn btn-sm btn-outline-success" href="{{ url_for('admin_activate', user_id=u.id) }}">Activer</a>
         {% endif %}
-        {% if current_user and current_user.email==SUPER_ADMIN_EMAIL and u.role!='admin' %}
+        {% if current_user and current_user.role==ROLE_SUPERADMIN and u.role!=ROLE_ADMIN %}
           <a class="btn btn-sm btn-outline-primary" href="{{ url_for('admin_promote', user_id=u.id) }}">Promouvoir admin</a>
         {% endif %}
       </td>


### PR DESCRIPTION
## Summary
- Introduce explicit role constants (`ROLE_SUPERADMIN`, `ROLE_ADMIN`, `ROLE_USER`) and use them across the app
- Seed database with default accounts including a super administrator
- Add admin interface routes to list users and promote them to admin

## Testing
- `python -m py_compile models.py app.py seed.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6bae7f0148330bca4bbad600970e8