### PR TITLE
Add role-based access control decorator and custom 403 page

### DIFF
--- a/templates/403.html
+++ b/templates/403.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+  <h1>Accès interdit</h1>
+  <p>Vous n'avez pas les droits nécessaires pour accéder à cette page.</p>
+{% endblock %}


### PR DESCRIPTION
## Summary
- implement `current_user` helper and `role_required` decorator for role checks
- protect admin views with role-based decorator and show custom 403 page
- add dedicated 403 template for forbidden access

## Testing
- `python -m py_compile app.py`
- `pytest`
- `flake8 app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6bc0614ac8330ab75f9bb94115c9d