### PR TITLE
feat: support admin role lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,24 @@
 # Vehicules (Flask)
 
 Application Flask de gestion des véhicules.
+
+## Rôles administratifs
+
+Lors de la création d'un compte via `/register` ou `/first_login`,
+l'application vérifie si l'adresse e‑mail figure dans les variables
+d'environnement `SUPERADMIN_EMAILS` ou `ADMIN_EMAILS`.
+
+* `SUPERADMIN_EMAILS` – adresses séparées par des virgules qui recevront le
+  rôle `superadmin`.
+* `ADMIN_EMAILS` – adresses séparées par des virgules qui recevront le rôle
+  `admin`.
+
+## Promotion/Déclassement
+
+Les rôles des comptes existants peuvent être modifiés via le script CLI :
+
+```bash
+python tools/create_admin.py <email> <role>
+```
+
+`<role>` peut être `user`, `admin` ou `superadmin`.

--- a/app.py
+++ b/app.py
@@ -103,11 +103,13 @@ def register():
     form = RegisterForm()
     if form.validate_on_submit():
         name = f"{form.last_name.data} {form.first_name.data}"
-        user = User(
-            name=name,
-            email=form.email.data.lower(),
-            role=User.ROLE_USER,
-        )
+        email = form.email.data.lower()
+        role = User.ROLE_USER
+        if email in app.config.get("SUPERADMIN_EMAILS", []):
+            role = User.ROLE_SUPERADMIN
+        elif email in app.config.get("ADMIN_EMAILS", []):
+            role = User.ROLE_ADMIN
+        user = User(name=name, email=email, role=role)
         user.set_password(form.password.data)
         db.session.add(user)
         try:
@@ -126,10 +128,14 @@ def first_login():
     form = FirstLoginForm()
     if form.validate_on_submit():
         name = f"{form.last_name.data} {form.first_name.data}"
-        user = User(name=name, email=form.email.data.lower())
+        email = form.email.data.lower()
+        role = User.ROLE_USER
+        if email in app.config.get("SUPERADMIN_EMAILS", []):
+            role = User.ROLE_SUPERADMIN
+        elif email in app.config.get("ADMIN_EMAILS", []):
+            role = User.ROLE_ADMIN
+        user = User(name=name, email=email, role=role)
         user.set_password(form.password.data)
-        if form.email.data in app.config.get("ADMIN_EMAILS", []):
-            user.role = User.ROLE_ADMIN
         db.session.add(user)
         try:
             db.session.commit()

--- a/config.py
+++ b/config.py
@@ -10,5 +10,16 @@ class Config:
     MAIL_USE_TLS = os.environ.get("MAIL_USE_TLS","1") == "1"
     MAIL_USERNAME = os.environ.get("MAIL_USERNAME","")
     MAIL_PASSWORD = os.environ.get("MAIL_PASSWORD","")
-    MAIL_DEFAULT_SENDER = os.environ.get("MAIL_DEFAULT_SENDER", os.environ.get("MAIL_USERNAME","no-reply@csp.local"))
-    ADMIN_EMAILS = [e.strip() for e in os.environ.get("ADMIN_EMAILS","").split(",") if e.strip()]
+    MAIL_DEFAULT_SENDER = os.environ.get(
+        "MAIL_DEFAULT_SENDER", os.environ.get("MAIL_USERNAME", "no-reply@csp.local")
+    )
+    SUPERADMIN_EMAILS = [
+        e.strip().lower()
+        for e in os.environ.get("SUPERADMIN_EMAILS", "").split(",")
+        if e.strip()
+    ]
+    ADMIN_EMAILS = [
+        e.strip().lower()
+        for e in os.environ.get("ADMIN_EMAILS", "").split(",")
+        if e.strip()
+    ]

--- a/tools/create_admin.py
+++ b/tools/create_admin.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Promote or demote user accounts."""
+
+import argparse
+import os
+import sys
+
+# Ensure repository root is in import path
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)
+
+from app import app
+from models import db, User
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Promote or demote a user by setting their role"
+    )
+    parser.add_argument("email", help="Email of the target user")
+    parser.add_argument(
+        "role",
+        choices=[User.ROLE_SUPERADMIN, User.ROLE_ADMIN, User.ROLE_USER],
+        help="Role to assign to the user",
+    )
+    args = parser.parse_args()
+
+    with app.app_context():
+        user = User.query.filter_by(email=args.email.lower()).first()
+        if not user:
+            print("User not found")
+            return 1
+        user.role = args.role
+        db.session.commit()
+        print(f"{user.email} is now '{user.role}'")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- auto-assign user roles based on configurable SUPERADMIN_EMAILS and ADMIN_EMAILS
- add CLI tool to promote/demote users
- document role management in README

## Testing
- `python -m pytest`
- `python tools/create_admin.py -h`

------
https://chatgpt.com/codex/tasks/task_e_68a6bdbcdab083308e714e2f81f5aefa