### PR TITLE
feat: add password confirmation for registration

### DIFF
--- a/app.py
+++ b/app.py
@@ -111,6 +111,9 @@ def login():
 def register():
     form = RegisterForm()
     if form.validate_on_submit():
+        if form.password.data != form.password2.data:
+            flash("Les mots de passe doivent correspondre", "danger")
+            return render_template("register.html", form=form), 200
         name = f"{form.last_name.data} {form.first_name.data}"
         email = form.email.data.lower()
         role = User.ROLE_USER

--- a/forms.py
+++ b/forms.py
@@ -30,6 +30,16 @@ class RegisterForm(FlaskForm):
     password = PasswordField(
         "Mot de passe", validators=[DataRequired(), Length(min=8)]
     )
+    password2 = PasswordField(
+        "Confirmer le mot de passe",
+        validators=[
+            DataRequired(),
+            EqualTo(
+                "password",
+                message="Les mots de passe doivent correspondre.",
+            ),
+        ],
+    )
     team_code = StringField("Code d'équipe", validators=[DataRequired(), Length(max=60)])
     submit = SubmitField("Créer mon compte")
 

--- a/templates/register.html
+++ b/templates/register.html
@@ -9,6 +9,7 @@
   </div>
   <div class="mb-3"><label class="form-label">Email (identifiant)</label><input name="email" type="email" class="form-control" required></div>
   <div class="mb-3"><label class="form-label">Mot de passe</label><input name="password" type="password" class="form-control" required minlength="10"><div class="form-text">≥ 10 car., 1 maj, 1 min, 1 chiffre.</div></div>
+  <div class="mb-3"><label class="form-label">Confirmer le mot de passe</label><input name="password2" type="password" class="form-control" required minlength="10"></div>
   <div class="mb-3"><label class="form-label">Code d’équipe</label><input name="team_code" class="form-control" required></div>
   <button class="btn btn-success w-100" type="submit">Créer le compte</button>
 </form>


### PR DESCRIPTION
## Summary
- add `password2` confirmation field to `RegisterForm`
- show confirmation input on registration page
- ensure `/register` route verifies matching passwords before user creation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a6de34b0c48330a37953d9ee80ff5d