### PR TITLE
Remove unused team code from registration flow

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,6 +110,7 @@ def login():
 @app.route("/register", methods=["GET", "POST"])
 def register():
     form = RegisterForm()
+    # Le code d'équipe n'est plus requis à l'inscription.
     if form.validate_on_submit():
         name = f"{form.last_name.data} {form.first_name.data}"
         email = form.email.data.lower()

--- a/forms.py
+++ b/forms.py
@@ -30,7 +30,6 @@ class RegisterForm(FlaskForm):
     password = PasswordField(
         "Mot de passe", validators=[DataRequired(), Length(min=8)]
     )
-    team_code = StringField("Code d'équipe", validators=[DataRequired(), Length(max=60)])
     submit = SubmitField("Créer mon compte")
 
 class NewRequestForm(FlaskForm):

--- a/templates/register.html
+++ b/templates/register.html
@@ -9,7 +9,6 @@
   </div>
   <div class="mb-3"><label class="form-label">Email (identifiant)</label><input name="email" type="email" class="form-control" required></div>
   <div class="mb-3"><label class="form-label">Mot de passe</label><input name="password" type="password" class="form-control" required minlength="10"><div class="form-text">≥ 10 car., 1 maj, 1 min, 1 chiffre.</div></div>
-  <div class="mb-3"><label class="form-label">Code d’équipe</label><input name="team_code" class="form-control" required></div>
   <button class="btn btn-success w-100" type="submit">Créer le compte</button>
 </form>
 <hr class="my-3"><div class="text-center"><a href="{{ url_for('login') }}">Déjà un compte ? Se connecter</a></div>


### PR DESCRIPTION
## Summary
- Drop obsolete team code field from registration form and page
- Clarify `/register` route to reflect removal of team code requirement

## Testing
- `pytest -q`
- `python -m py_compile forms.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a6de385940833083ee1e3435f1d7cb