### PR TITLE
Remove unused SelectField import

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,6 +1,6 @@
 
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, SubmitField, SelectField, BooleanField, DateTimeLocalField, TextAreaField
+from wtforms import StringField, PasswordField, SubmitField, BooleanField, DateTimeLocalField, TextAreaField
 from wtforms.validators import DataRequired, Email, Length, EqualTo
 
 class LoginForm(FlaskForm):


### PR DESCRIPTION
## Summary
- remove unused `SelectField` from `wtforms` imports in `forms.py`

## Testing
- `pytest -q`
- `ruff check .` *(fails: notify.py unused variable, seed.py ambiguous var, tools/create_admin.py import order)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e472c71083308ac865054e8c7cf8