### PR TITLE
Refine role-based navigation

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -4,8 +4,6 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-{% if user and user.role in ("chef","adjoint") %}
-{% endif %}
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="{{ url_for('static', filename='styles.css') }}" rel="stylesheet">
 <style> .user-name{max-width:12rem} @media (max-width:576px){ .user-name{max-width:8rem} } </style>
@@ -13,20 +11,19 @@
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-3">
   <div class="container">
-{% if user and user.role in ("chef","adjoint") %}
-{% endif %}
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#nav">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse" id="nav">
       <ul class="navbar-nav me-auto">
-        {% if user and user.role in ['chef','adjoint'] %}
-          <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_reservations') }}">Réservations</a></li>
-          {% if user and user.role in ("chef","adjoint") %}
-          <li><a href="{{ url_for('admin_vehicles') }}">Véhicules CSP</a></li>
-          {% endif %}
-        {% endif %}
         {% if user %}
+          {% if user.role in ['admin', 'superadmin'] %}
+            <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_vehicles') }}">Gestion du parc</a></li>
+            <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_reservations') }}">Reservation</a></li>
+            {% if user.role == 'superadmin' %}
+              <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_users') }}">Gestion du Statut Utilisateur</a></li>
+            {% endif %}
+          {% endif %}
           <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('calendar_month') }}">Vue mensuelle</a></li>
           <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('new_request') }}">Nouvelle demande</a></li>
         {% endif %}


### PR DESCRIPTION
## Summary
- Build navigation menu based on `user`, `admin`, and `superadmin` roles.
- Add admin and superadmin tabs for vehicle management, reservations, and user status.
- Keep logged-in user's name and role visible.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72c36dfdc8330b7cbab99a09828e8