### PR TITLE
Redirect home view to monthly calendar

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,10 +85,7 @@ def forbidden(_):
 @app.route("/home")
 @app.route("/")
 def home():
-    vehicles = Vehicle.query.order_by(Vehicle.code).all()
-    return render_template(
-        "home.html", vehicles=vehicles, user=current_user()
-    )
+    return redirect(url_for("calendar_month"))
 
 
 # --- Routes de connexion


### PR DESCRIPTION
## Summary
- Redirect `home` route to the monthly calendar view
- Keep login handler redirecting to `home` so users land on the calendar after login

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73020e70c8330a96050256f2ed92f