### PR TITLE
Add admin vehicle CRUD routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -211,6 +211,61 @@ def admin_promote(user_id):
     return redirect(url_for("admin_users"))
 
 
+@app.route("/admin/vehicles")
+@role_required("admin", "superadmin")
+def admin_vehicles():
+    user = current_user()
+    vehicles = Vehicle.query.order_by(Vehicle.code).all()
+    return render_template(
+        "admin_vehicles.html",
+        vehicles=vehicles,
+        user=user,
+        current_user=user,
+    )
+
+
+@app.route("/admin/vehicles/new", methods=["GET", "POST"])
+@role_required("admin", "superadmin")
+def admin_vehicle_new():
+    if request.method == "POST":
+        v = Vehicle(
+            code=request.form["code"].strip(),
+            label=request.form["label"].strip(),
+        )
+        db.session.add(v)
+        db.session.commit()
+        flash("Véhicule créé", "success")
+        return redirect(url_for("admin_vehicles"))
+    return render_template(
+        "vehicle_form.html", vehicle=None, user=current_user()
+    )
+
+
+@app.route("/admin/vehicles/<int:vehicle_id>/edit", methods=["GET", "POST"])
+@role_required("admin", "superadmin")
+def admin_vehicle_edit(vehicle_id):
+    vehicle = Vehicle.query.get_or_404(vehicle_id)
+    if request.method == "POST":
+        vehicle.code = request.form["code"].strip()
+        vehicle.label = request.form["label"].strip()
+        db.session.commit()
+        flash("Véhicule mis à jour", "success")
+        return redirect(url_for("admin_vehicles"))
+    return render_template(
+        "vehicle_form.html", vehicle=vehicle, user=current_user()
+    )
+
+
+@app.route("/admin/vehicles/<int:vehicle_id>/delete")
+@role_required("admin", "superadmin")
+def admin_vehicle_delete(vehicle_id):
+    vehicle = Vehicle.query.get_or_404(vehicle_id)
+    db.session.delete(vehicle)
+    db.session.commit()
+    flash("Véhicule supprimé", "info")
+    return redirect(url_for("admin_vehicles"))
+
+
 @app.route("/calendar/month")
 def calendar_month():
     user = current_user()

--- a/templates/admin_vehicles.html
+++ b/templates/admin_vehicles.html
@@ -2,12 +2,23 @@
 {% block content %}
 <div class="container">
   <h2>Véhicules CSP</h2>
+  <div class="mb-3">
+    <a class="btn btn-primary" href="{{ url_for('admin_vehicle_new') }}">Nouveau véhicule</a>
+  </div>
   {% if vehicles %}
   <table class="table table-striped">
-    <thead><tr><th>Code</th><th>Libellé</th><th>Catégorie</th></tr></thead>
+    <thead><tr><th>Code</th><th>Libellé</th><th>Catégorie</th><th></th></tr></thead>
     <tbody>
       {% for v in vehicles %}
-      <tr><td>{{ v.code }}</td><td>{{ v.label }}</td><td>{{ v.category or "" }}</td></tr>
+      <tr>
+        <td>{{ v.code }}</td>
+        <td>{{ v.label }}</td>
+        <td>{{ v.category or "" }}</td>
+        <td class="text-end">
+          <a class="btn btn-sm btn-secondary" href="{{ url_for('admin_vehicle_edit', vehicle_id=v.id) }}">Modifier</a>
+          <a class="btn btn-sm btn-danger" href="{{ url_for('admin_vehicle_delete', vehicle_id=v.id) }}">Supprimer</a>
+        </td>
+      </tr>
       {% endfor %}
     </tbody>
   </table>

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,7 @@
         {% if user %}
           {% if user.role in ['admin', 'superadmin'] %}
             <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_vehicles') }}">Gestion du parc</a></li>
+            <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_vehicle_new') }}">Ajouter un véhicule</a></li>
             <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_reservations') }}">Reservation</a></li>
             {% if user.role == 'superadmin' %}
               <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_users') }}">Gestion du Statut Utilisateur</a></li>


### PR DESCRIPTION
## Summary
- implement admin routes for listing and managing vehicles
- enable admins to create, edit, and delete vehicles
- expose vehicle management links in navigation

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a737e4250883309192a217a2490a33