### PR TITLE
Restrict PDF export button to admin roles

### DIFF
--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -30,7 +30,7 @@
   </tbody>
 </table>
 <p class="text-muted">Légende : <span class="badge bg-success">R</span> = Réservé (approuvé)</p>
-{% if user and user.role in ['chef','adjoint'] %}
+{% if user and user.role in ['admin', 'superadmin'] %}
   <a class="btn btn-outline-secondary" href="{{ url_for('export_pdf_month') }}">Exporter PDF du mois</a>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- limit PDF export in monthly calendar to users with roles `admin` or `superadmin`

## Testing
- `pytest`
- `python /tmp/render.py`


------
https://chatgpt.com/codex/tasks/task_e_68a73df1a9c883308897b132743afc4c