### PR TITLE
Add admin dashboard and restrict home access

### DIFF
--- a/app.py
+++ b/app.py
@@ -100,7 +100,10 @@ def forbidden(_):
 @app.route("/home")
 @app.route("/")
 def home():
-    return redirect(url_for("calendar_month"))
+    u = current_user()
+    if not u or u.role not in (User.ROLE_ADMIN, User.ROLE_SUPERADMIN):
+        return redirect(url_for("calendar_month"))
+    return render_template("home.html", user=u, current_user=u)
 
 
 # --- Routes de connexion

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,14 +17,7 @@
     <div class="collapse navbar-collapse" id="nav">
       <ul class="navbar-nav me-auto">
         {% if user %}
-          {% if user.role in ['admin', 'superadmin'] %}
-            <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_vehicles') }}">Gestion du parc</a></li>
-            <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_vehicle_new') }}">Ajouter un véhicule</a></li>
-            <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_reservations') }}">Reservation</a></li>
-            {% if user.role == 'superadmin' %}
-              <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('admin_users') }}">Gestion du Statut Utilisateur</a></li>
-            {% endif %}
-          {% endif %}
+          <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('home') }}">Accueil</a></li>
           <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('calendar_month') }}">Vue mensuelle</a></li>
           <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('new_request') }}">Nouvelle demande</a></li>
         {% endif %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,17 +1,11 @@
-
 {% extends "base.html" %}
 {% block content %}
-<h1 class="h4">Parc véhicules</h1>
-<div class="row mt-3">
-  {% for v in vehicles %}
-  <div class="col-md-4">
-    <div class="card mb-3">
-      <div class="card-body">
-        <h5 class="card-title">{{ v.code }}</h5>
-        <p class="card-text">{{ v.label }} — {{ v.seats }} places</p>
-      </div>
-    </div>
-  </div>
-  {% endfor %}
+<h1 class="h4">Accueil administration</h1>
+<div class="list-group">
+  <a class="list-group-item list-group-item-action" href="{{ url_for('admin_users') }}">Gestion des utilisateurs</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('admin_vehicles') }}">Gestion du parc</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('admin_reservations') }}">Gestion des réservations</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Vue mensuelle</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Nouvelle demande</a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Render new admin dashboard template from `home` route
- Show navigation links for administrators in dashboard instead of navbar
- Simplify navbar to avoid duplicate admin links

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7676dbe2c8330b45bfe64a304616c