### PR TITLE
Add user activation status management

### DIFF
--- a/app.py
+++ b/app.py
@@ -229,6 +229,26 @@ def admin_promote(user_id):
     return redirect(url_for("admin_users"))
 
 
+@app.route("/admin/activate/<int:user_id>")
+@role_required("admin", "superadmin")
+def admin_activate(user_id):
+    target = User.query.get_or_404(user_id)
+    target.status = "active"
+    db.session.commit()
+    flash("Utilisateur activé", "success")
+    return redirect(url_for("admin_users"))
+
+
+@app.route("/admin/deactivate/<int:user_id>")
+@role_required("admin", "superadmin")
+def admin_deactivate(user_id):
+    target = User.query.get_or_404(user_id)
+    target.status = "inactive"
+    db.session.commit()
+    flash("Utilisateur désactivé", "warning")
+    return redirect(url_for("admin_users"))
+
+
 @app.route("/admin/vehicles")
 @role_required("admin", "superadmin")
 def admin_vehicles():

--- a/models.py
+++ b/models.py
@@ -14,6 +14,7 @@ class User(db.Model):
     email = db.Column(db.String(120), unique=True, nullable=False)
     role = db.Column(db.String(50), default=ROLE_USER)
     password_hash = db.Column(db.String(255), nullable=False)
+    status = db.Column(db.String(20), default="pending")
 
     def set_password(self, pwd):
         self.password_hash = generate_password_hash(pwd)

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -10,9 +10,11 @@
       <td>{{u.last_name or ""}}</td>
       <td>{{u.email}}</td>
       <td><span class="badge bg-{{ 'primary' if u.role==ROLE_ADMIN else 'secondary' }}">{{u.role or 'user'}}</span></td>
-      <td><span class="badge bg-{{ 'success' if (u.status or '')=='active' else 'warning' }}">{{u.status or 'n/a'}}</span></td>
+      <td><span class="badge bg-{{ 'success' if (u.status or '')=='active' else ('secondary' if (u.status or '')=='inactive' else 'warning') }}">{{u.status or 'n/a'}}</span></td>
       <td class="d-flex gap-2">
-        {% if (u.status or '') != 'active' %}
+        {% if (u.status or '') == 'active' %}
+          <a class="btn btn-sm btn-outline-warning" href="{{ url_for('admin_deactivate', user_id=u.id) }}">Désactiver</a>
+        {% else %}
           <a class="btn btn-sm btn-outline-success" href="{{ url_for('admin_activate', user_id=u.id) }}">Activer</a>
         {% endif %}
         {% if current_user and current_user.role==ROLE_SUPERADMIN and u.role!=ROLE_ADMIN %}


### PR DESCRIPTION
## Summary
- add `status` field to `User` model
- allow admins to activate or deactivate users
- show activation controls in admin user list

## Testing
- `python -m py_compile models.py app.py`
- `python seed.py`


------
https://chatgpt.com/codex/tasks/task_e_68a986d5bc748330bbc97696311a89c8