### PR TITLE
Restrict role changes to superadmin and add demotion

### DIFF
--- a/app.py
+++ b/app.py
@@ -220,12 +220,22 @@ def admin_users():
 
 
 @app.route("/admin/promote/<int:user_id>")
-@role_required("admin", "superadmin")
+@role_required("superadmin")
 def admin_promote(user_id):
     target = User.query.get_or_404(user_id)
     target.role = User.ROLE_ADMIN
     db.session.commit()
     flash("Utilisateur promu administrateur", "success")
+    return redirect(url_for("admin_users"))
+
+
+@app.route("/admin/demote/<int:user_id>")
+@role_required("superadmin")
+def admin_demote(user_id):
+    target = User.query.get_or_404(user_id)
+    target.role = User.ROLE_USER
+    db.session.commit()
+    flash("Utilisateur rétrogradé", "info")
     return redirect(url_for("admin_users"))
 
 

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -17,8 +17,12 @@
         {% else %}
           <a class="btn btn-sm btn-outline-success" href="{{ url_for('admin_activate', user_id=u.id) }}">Activer</a>
         {% endif %}
-        {% if current_user and current_user.role==ROLE_SUPERADMIN and u.role!=ROLE_ADMIN %}
-          <a class="btn btn-sm btn-outline-primary" href="{{ url_for('admin_promote', user_id=u.id) }}">Promouvoir admin</a>
+        {% if current_user and current_user.role==ROLE_SUPERADMIN and u.role!=ROLE_SUPERADMIN %}
+          {% if u.role==ROLE_ADMIN %}
+            <a class="btn btn-sm btn-outline-primary" href="{{ url_for('admin_demote', user_id=u.id) }}">Rétrograder</a>
+          {% else %}
+            <a class="btn btn-sm btn-outline-primary" href="{{ url_for('admin_promote', user_id=u.id) }}">Promouvoir admin</a>
+          {% endif %}
         {% endif %}
       </td>
     </tr>


### PR DESCRIPTION
## Summary
- limit promoting users to admins to superadmins only
- add route to demote admins back to regular users
- toggle user admin action button based on current role

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9882c5334833090edf1dbb5362c8b