### PR TITLE
feat: allow superadmins to delete users

### DIFF
--- a/app.py
+++ b/app.py
@@ -259,6 +259,21 @@ def admin_deactivate(user_id):
     return redirect(url_for("admin_users"))
 
 
+@app.route("/admin/delete/<int:user_id>")
+@role_required("superadmin")
+def admin_user_delete(user_id):
+    target = User.query.get_or_404(user_id)
+    if target.role == User.ROLE_SUPERADMIN:
+        flash("Impossible de supprimer un superadministrateur", "danger")
+        return redirect(url_for("admin_users"))
+    # Suppression en cascade des réservations associées
+    Reservation.query.filter_by(user_id=target.id).delete()
+    db.session.delete(target)
+    db.session.commit()
+    flash("Utilisateur supprimé", "info")
+    return redirect(url_for("admin_users"))
+
+
 @app.route("/admin/vehicles")
 @role_required("admin", "superadmin")
 def admin_vehicles():

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -23,6 +23,7 @@
           {% else %}
             <a class="btn btn-sm btn-outline-primary" href="{{ url_for('admin_promote', user_id=u.id) }}">Promouvoir admin</a>
           {% endif %}
+          <a class="btn btn-sm btn-outline-danger" href="{{ url_for('admin_user_delete', user_id=u.id) }}" onclick="return confirm('Confirmer la suppression ?');">Supprimer</a>
         {% endif %}
       </td>
     </tr>


### PR DESCRIPTION
## Summary
- add superadmin-only endpoint to delete users and their reservations
- add delete button with client-side confirmation in admin user list

## Testing
- `pytest`
- `python -m py_compile app.py && echo 'py_compile: success'`


------
https://chatgpt.com/codex/tasks/task_e_68a9893f99408330bdd21aed9bf78931