### PR TITLE
Ajout des champs prénom/nom et édition des utilisateurs

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,7 +1,16 @@
 
 from flask_wtf import FlaskForm
-from wtforms import StringField, PasswordField, SubmitField, BooleanField, DateTimeLocalField, TextAreaField
+from wtforms import (
+    StringField,
+    PasswordField,
+    SubmitField,
+    BooleanField,
+    DateTimeLocalField,
+    TextAreaField,
+    SelectField,
+)
 from wtforms.validators import DataRequired, Email, Length, EqualTo
+from models import User
 
 class LoginForm(FlaskForm):
     email = StringField("Email", validators=[DataRequired(), Email()])
@@ -53,3 +62,18 @@ class NewRequestForm(FlaskForm):
     carpool_with = StringField("Avec qui")
     notes = TextAreaField("Précisions", validators=[Length(max=1000)])
     submit = SubmitField("Envoyer la demande")
+
+
+class UserForm(FlaskForm):
+    first_name = StringField("Prénom", validators=[DataRequired(), Length(max=60)])
+    last_name = StringField("Nom", validators=[DataRequired(), Length(max=60)])
+    email = StringField("Email", validators=[DataRequired(), Email(), Length(max=120)])
+    role = SelectField(
+        "Rôle",
+        choices=[
+            (User.ROLE_USER, "user"),
+            (User.ROLE_ADMIN, "admin"),
+            (User.ROLE_SUPERADMIN, "superadmin"),
+        ],
+    )
+    submit = SubmitField("Enregistrer")

--- a/models.py
+++ b/models.py
@@ -11,6 +11,8 @@ class User(db.Model):
 
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(120), nullable=False)
+    first_name = db.Column(db.String(60), nullable=True)
+    last_name = db.Column(db.String(60), nullable=True)
     email = db.Column(db.String(120), unique=True, nullable=False)
     role = db.Column(db.String(50), default=ROLE_USER)
     password_hash = db.Column(db.String(255), nullable=False)

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -12,6 +12,7 @@
       <td><span class="badge bg-{{ 'primary' if u.role==ROLE_ADMIN else 'secondary' }}">{{u.role or 'user'}}</span></td>
       <td><span class="badge bg-{{ 'success' if (u.status or '')=='active' else ('secondary' if (u.status or '')=='inactive' else 'warning') }}">{{u.status or 'n/a'}}</span></td>
       <td class="d-flex gap-2">
+        <a class="btn btn-sm btn-outline-secondary" href="{{ url_for('admin_user_edit', user_id=u.id) }}">Modifier</a>
         {% if (u.status or '') == 'active' %}
           <a class="btn btn-sm btn-outline-warning" href="{{ url_for('admin_deactivate', user_id=u.id) }}">Désactiver</a>
         {% else %}

--- a/templates/user_form.html
+++ b/templates/user_form.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Modifier utilisateur #{{ target.id }}</h2>
+<form method="post">
+  {{ form.hidden_tag() }}
+  <div class="mb-3">
+    {{ form.first_name.label(class="form-label") }}
+    {{ form.first_name(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.last_name.label(class="form-label") }}
+    {{ form.last_name(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.email.label(class="form-label") }}
+    {{ form.email(class="form-control") }}
+  </div>
+  <div class="mb-3">
+    {{ form.role.label(class="form-label") }}
+    {{ form.role(class="form-select") }}
+  </div>
+  <button class="btn btn-primary" type="submit">Enregistrer</button>
+  <a class="btn btn-secondary" href="{{ url_for('admin_users') }}">Annuler</a>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Ajout des champs `first_name` et `last_name` au modèle `User`
- Mise à jour de l'inscription et du premier login pour enregistrer ces informations
- Nouveau `UserForm` et interface `/admin/user/<id>/edit`

## Testing
- `python -m py_compile app.py forms.py models.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a98a052bdc833083cee64a89bf7c38