### PR TITLE
Add superadmin password reset feature

### DIFF
--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -18,6 +18,11 @@
         {% else %}
           <a class="btn btn-sm btn-outline-success" href="{{ url_for('admin_activate', user_id=u.id) }}">Activer</a>
         {% endif %}
+        {% if current_user and current_user.role==ROLE_SUPERADMIN %}
+          <form method="post" action="{{ url_for('admin_reset_password', user_id=u.id) }}" class="d-inline" onsubmit="return confirm('Réinitialiser le mot de passe ?');">
+            <button class="btn btn-sm btn-outline-secondary" type="submit">Réinitialiser mot de passe</button>
+          </form>
+        {% endif %}
         {% if current_user and current_user.role==ROLE_SUPERADMIN and u.role!=ROLE_SUPERADMIN %}
           {% if u.role==ROLE_ADMIN %}
             <a class="btn btn-sm btn-outline-primary" href="{{ url_for('admin_demote', user_id=u.id) }}">Rétrograder</a>


### PR DESCRIPTION
## Summary
- Add endpoint `/admin/reset_password/<id>` allowing superadmins to set a temporary password and notify the user
- Add button on users admin page to trigger password resets

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a98ae747708330bfca6474991b6db6