### PR TITLE
docs: add database initialization steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,12 @@ python tools/create_admin.py <email> <role>
 ```
 
 `<role>` peut être `user`, `admin` ou `superadmin`.
+
+## Initialisation de la base de données
+
+Pour repartir sur une base saine :
+
+1. Supprimez l'ancien fichier `vehicules.db` si nécessaire.
+2. Exécutez `flask db upgrade` ou `python seed.py` pour créer la base et appliquer les migrations.
+
+Sans migration appliquée, l'application échouera lors de la connexion avec des erreurs de colonnes manquantes.


### PR DESCRIPTION
## Summary
- document how to initialize the database, including removing old `vehicules.db`
- note that migrations are required to avoid missing column errors on login

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9b808b12c83309770f6142d2205f5