### PR TITLE
Masquer certains liens de navigation pour les superadmins

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,8 +18,10 @@
       <ul class="navbar-nav me-auto">
         {% if user %}
           <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('home') }}">Accueil</a></li>
-          <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('calendar_month') }}">Vue mensuelle</a></li>
-          <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('new_request') }}">Nouvelle demande</a></li>
+          {% if user.role != 'superadmin' %}
+            <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('calendar_month') }}">Vue mensuelle</a></li>
+            <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('new_request') }}">Nouvelle demande</a></li>
+          {% endif %}
         {% endif %}
       </ul>
       <ul class="navbar-nav ms-auto align-items-center">

--- a/tests/test_navigation_links.py
+++ b/tests/test_navigation_links.py
@@ -1,0 +1,30 @@
+import os
+import sys
+
+import pytest
+from flask import render_template
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app
+from models import User
+
+
+def _render(role: str) -> str:
+    with app.test_request_context('/'):
+        user = User(name='Test', email='test@example.com', role=role, password_hash='x')
+        return render_template('base.html', user=user)
+
+
+def test_links_hidden_for_superadmin():
+    html = _render(User.ROLE_SUPERADMIN)
+    assert 'Vue mensuelle' not in html
+    assert 'Nouvelle demande' not in html
+    assert 'Accueil' in html
+
+
+@pytest.mark.parametrize('role', [User.ROLE_ADMIN, User.ROLE_USER])
+def test_links_visible_for_other_roles(role):
+    html = _render(role)
+    assert 'Vue mensuelle' in html
+    assert 'Nouvelle demande' in html
+    assert 'Accueil' in html


### PR DESCRIPTION
## Summary
- Cache les liens "Vue mensuelle" et "Nouvelle demande" pour le rôle superadmin
- Ajoute des tests pour vérifier la visibilité des liens selon le rôle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9c6ef39e083309b693c4706f2212b