### PR TITLE
Remove calendar/request links from navbar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -18,10 +18,6 @@
       <ul class="navbar-nav me-auto">
         {% if user %}
           <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('home') }}">Accueil</a></li>
-          {% if user.role != 'superadmin' %}
-            <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('calendar_month') }}">Vue mensuelle</a></li>
-            <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('new_request') }}">Nouvelle demande</a></li>
-          {% endif %}
         {% endif %}
       </ul>
       <ul class="navbar-nav ms-auto align-items-center">

--- a/tests/test_navigation_links.py
+++ b/tests/test_navigation_links.py
@@ -15,16 +15,9 @@ def _render(role: str) -> str:
         return render_template('base.html', user=user)
 
 
-def test_links_hidden_for_superadmin():
-    html = _render(User.ROLE_SUPERADMIN)
+@pytest.mark.parametrize('role', [User.ROLE_SUPERADMIN, User.ROLE_ADMIN, User.ROLE_USER])
+def test_navbar_contains_only_home(role):
+    html = _render(role)
+    assert 'Accueil' in html
     assert 'Vue mensuelle' not in html
     assert 'Nouvelle demande' not in html
-    assert 'Accueil' in html
-
-
-@pytest.mark.parametrize('role', [User.ROLE_ADMIN, User.ROLE_USER])
-def test_links_visible_for_other_roles(role):
-    html = _render(role)
-    assert 'Vue mensuelle' in html
-    assert 'Nouvelle demande' in html
-    assert 'Accueil' in html


### PR DESCRIPTION
## Summary
- Simplify base navbar to only include home and user info
- Update navigation link tests for new navbar structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aaa7d6162083309b82d82cf7389a9f