### PR TITLE
Add month navigation to calendar view

### DIFF
--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -1,8 +1,19 @@
 
 {% extends "base.html" %}
 {% block content %}
+{# Calcul mois précédent et suivant #}
+{% set prev = start - timedelta(days=1) %}
+{% set prev_y = prev.year %}
+{% set prev_m = prev.month %}
+{% set next_y = end.year %}
+{% set next_m = end.month %}
+
 <h1 class="h4">Vue mensuelle (lecture seule)</h1>
-<p>Mois: {{ start.strftime('%B %Y') }}</p>
+<p>
+  <a href="{{ url_for('calendar_month', y=prev_y, m=prev_m) }}">&larr;</a>
+  Mois: {{ start.strftime('%B %Y') }}
+  <a href="{{ url_for('calendar_month', y=next_y, m=next_m) }}">&rarr;</a>
+</p>
 {% set days = (end - start).days %}
 <table class="table table-bordered table-sm align-middle">
   <thead>

--- a/tests/test_calendar_month_nav.py
+++ b/tests/test_calendar_month_nav.py
@@ -1,0 +1,48 @@
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+from flask import render_template
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app
+from models import User
+
+
+@pytest.mark.parametrize('role', [User.ROLE_USER, User.ROLE_ADMIN, User.ROLE_SUPERADMIN])
+def test_calendar_links_visible(role):
+    start = datetime(2024, 3, 1)
+    end = datetime(2024, 4, 1)
+    with app.test_request_context('/calendar/month'):
+        user = User(name='Test', email='test@example.com', role=role, password_hash='x')
+        html = render_template(
+            'calendar_month.html',
+            vehicles=[],
+            reservations=[],
+            start=start,
+            end=end,
+            user=user,
+            timedelta=timedelta,
+        )
+    assert '?y=2024&amp;m=2' in html
+    assert '?y=2024&amp;m=4' in html
+
+
+def test_calendar_month_params_interpreted():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    from models import db
+    with app.app_context():
+        db.create_all()
+        user = User(name='User', email='user@example.com', role=User.ROLE_USER, password_hash='x')
+        db.session.add(user)
+        db.session.commit()
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['uid'] = user.id
+        resp = client.get('/calendar/month?y=2023&m=12')
+        html = resp.data.decode('utf-8')
+        assert '?y=2023&amp;m=11' in html
+        assert '?y=2024&amp;m=1' in html
+        db.drop_all()


### PR DESCRIPTION
## Summary
- compute previous and next month references from current start date
- add left/right navigation arrows to monthly calendar template
- test navigation links visibility for all roles and parameter parsing in `calendar_month`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1aae76ec4833098543b7ea1ac9875