### PR TITLE
Remove debugging div from request management template

### DIFF
--- a/templates/manage_request.html
+++ b/templates/manage_request.html
@@ -12,8 +12,6 @@
 </div>
 
 <h2 class="h6">Disponibilité des véhicules</h2>
-<div class="small text-muted">debug: vehicles={{ vehicles|length if vehicles is defined else "undef" }}</div>
-
 <form method="post">
   <div class="mb-3">
     <label for="vehicle_id" class="form-label">Véhicule</label>


### PR DESCRIPTION
## Summary
- remove stray debug output from the request management page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1b291d59c8330b2fc4d14bc175c59