### PR TITLE
Display first and last name in navbar

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -22,7 +22,7 @@
       </ul>
       <ul class="navbar-nav ms-auto align-items-center">
         {% if user %}
-          <li class="nav-item me-2"><span class="navbar-text">{{ user.name }} — {{ user.role }}</span></li>
+          <li class="nav-item me-2"><span class="navbar-text">{{ user.first_name }} {{ user.last_name }} — {{ user.role }}</span></li>
           <li class="nav-item me-2"><a href="{{ url_for('logout') }}" class="btn btn-danger btn-sm">Déconnexion</a></li>
         {% else %}
           <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('login') }}">Connexion</a></li>

--- a/tests/test_calendar_month_nav.py
+++ b/tests/test_calendar_month_nav.py
@@ -15,7 +15,14 @@ def test_calendar_links_visible(role):
     start = datetime(2024, 3, 1)
     end = datetime(2024, 4, 1)
     with app.test_request_context('/calendar/month'):
-        user = User(name='Test', email='test@example.com', role=role, password_hash='x')
+        user = User(
+            name='Test User',
+            first_name='Test',
+            last_name='User',
+            email='test@example.com',
+            role=role,
+            password_hash='x',
+        )
         html = render_template(
             'calendar_month.html',
             vehicles=[],
@@ -35,7 +42,14 @@ def test_calendar_month_params_interpreted():
     from models import db
     with app.app_context():
         db.create_all()
-        user = User(name='User', email='user@example.com', role=User.ROLE_USER, password_hash='x')
+        user = User(
+            name='User Test',
+            first_name='User',
+            last_name='Test',
+            email='user@example.com',
+            role=User.ROLE_USER,
+            password_hash='x',
+        )
         db.session.add(user)
         db.session.commit()
         client = app.test_client()

--- a/tests/test_navigation_links.py
+++ b/tests/test_navigation_links.py
@@ -11,7 +11,14 @@ from models import User
 
 def _render_nav(role: str) -> str:
     with app.test_request_context('/'):
-        user = User(name='Test', email='test@example.com', role=role, password_hash='x')
+        user = User(
+            name='Test User',
+            first_name='Test',
+            last_name='User',
+            email='test@example.com',
+            role=role,
+            password_hash='x',
+        )
         return render_template('base.html', user=user)
 
 
@@ -30,7 +37,14 @@ def _render_home(role: str) -> str:
         User.ROLE_USER: 'user_home.html',
     }
     with app.test_request_context('/'):
-        user = User(name='Test', email='test@example.com', role=role, password_hash='x')
+        user = User(
+            name='Test User',
+            first_name='Test',
+            last_name='User',
+            email='test@example.com',
+            role=role,
+            password_hash='x',
+        )
         return render_template(templates[role], user=user, current_user=user)
 
 

--- a/tests/test_vehicle_admin.py
+++ b/tests/test_vehicle_admin.py
@@ -9,7 +9,14 @@ def client():
     app.config['TESTING'] = True
     with app.app_context():
         db.create_all()
-        admin = User(name='Admin', email='admin@example.com', role=User.ROLE_ADMIN, password_hash='x')
+        admin = User(
+            name='Admin User',
+            first_name='Admin',
+            last_name='User',
+            email='admin@example.com',
+            role=User.ROLE_ADMIN,
+            password_hash='x',
+        )
         db.session.add(admin)
         db.session.commit()
         client = app.test_client()


### PR DESCRIPTION
## Summary
- Show a user's first and last name explicitly in the base navbar
- Update tests to build users with `first_name` and `last_name`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1b7bf929883309f7ce1ca0658fdce