### PR TITLE
Add superadmin leaves management stub

### DIFF
--- a/app.py
+++ b/app.py
@@ -427,6 +427,13 @@ def admin_reservations():
     )
 
 
+@app.route("/admin/leaves")
+@role_required("superadmin")
+def admin_leaves():
+    user = current_user()
+    return render_template("admin_leaves.html", user=user, current_user=user)
+
+
 @app.route("/admin/manage/<int:rid>", methods=["GET", "POST"])
 @role_required("admin", "superadmin")
 def manage_request(rid):

--- a/templates/admin_leaves.html
+++ b/templates/admin_leaves.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="h4">Gestion des congés</h1>
+<p>Formulaire de configuration à venir.</p>
+{% endblock %}

--- a/templates/superadmin_home.html
+++ b/templates/superadmin_home.html
@@ -5,6 +5,7 @@
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_users') }}">Gestion des utilisateurs</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_vehicles') }}">Gestion du parc</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_reservations') }}">Gestion des réservations</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('admin_leaves') }}">Gestion des congés</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Vue mensuelle</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Nouvelle demande</a>
 </div>

--- a/tests/test_navigation_links.py
+++ b/tests/test_navigation_links.py
@@ -62,6 +62,7 @@ def _render_home(role: str) -> str:
                 'Gestion des utilisateurs',
                 'Gestion du parc',
                 'Gestion des réservations',
+                'Gestion des congés',
                 'Vue mensuelle',
                 'Nouvelle demande',
             ],


### PR DESCRIPTION
## Summary
- add "Gestion des congés" link on superadmin home
- create protected `/admin/leaves` route returning new template
- adjust navigation tests for new link

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b570c3e5c083308891930ff5fb5f03