### PR TITLE
feat: allow selecting notification recipients

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -8,9 +8,15 @@ from wtforms import (
     DateTimeLocalField,
     TextAreaField,
     SelectField,
+    SelectMultipleField,
 )
 from wtforms.validators import DataRequired, Email, Length, EqualTo
+from wtforms.widgets import CheckboxInput, ListWidget
 from models import User
+
+class MultiCheckboxField(SelectMultipleField):
+    widget = ListWidget(prefix_label=False)
+    option_widget = CheckboxInput()
 
 class LoginForm(FlaskForm):
     email = StringField("Email", validators=[DataRequired(), Email()])
@@ -80,6 +86,5 @@ class UserForm(FlaskForm):
 
 
 class NotificationSettingsForm(FlaskForm):
-    notify_superadmin = BooleanField("Alerter les superadmins")
-    notify_admin = BooleanField("Alerter les admins")
+    recipients = MultiCheckboxField("Notifier", choices=[])
     submit = SubmitField("Enregistrer")

--- a/migrations/versions/b9f8d1e7e3c9_add_notify_user_ids.py
+++ b/migrations/versions/b9f8d1e7e3c9_add_notify_user_ids.py
@@ -1,0 +1,23 @@
+"""add notify_user_ids to notification settings
+
+Revision ID: b9f8d1e7e3c9
+Revises: 3b1436a41c1b
+Create Date: 2024-01-01 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'b9f8d1e7e3c9'
+down_revision = '3b1436a41c1b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('notification_settings', sa.Column('notify_user_ids', sa.JSON(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('notification_settings', 'notify_user_ids')

--- a/models.py
+++ b/models.py
@@ -52,3 +52,4 @@ class NotificationSettings(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     notify_superadmin = db.Column(db.Boolean, default=False)
     notify_admin = db.Column(db.Boolean, default=False)
+    notify_user_ids = db.Column(db.JSON, default=list)

--- a/templates/admin_leaves.html
+++ b/templates/admin_leaves.html
@@ -3,14 +3,12 @@
 <h1 class="h4">Notifications de demandes</h1>
 <form method="post">
   {{ form.hidden_tag() }}
+  {% for subfield in form.recipients %}
   <div class="form-check">
-    {{ form.notify_superadmin(class="form-check-input") }}
-    {{ form.notify_superadmin.label(class="form-check-label") }}
+    {{ subfield(class="form-check-input") }}
+    {{ subfield.label(class="form-check-label") }}
   </div>
-  <div class="form-check">
-    {{ form.notify_admin(class="form-check-input") }}
-    {{ form.notify_admin.label(class="form-check-label") }}
-  </div>
+  {% endfor %}
   {{ form.submit(class="btn btn-primary mt-3") }}
 </form>
 {% endblock %}

--- a/tests/test_calendar_month_nav.py
+++ b/tests/test_calendar_month_nav.py
@@ -41,6 +41,8 @@ def test_calendar_month_params_interpreted():
     app.config['TESTING'] = True
     from models import db
     with app.app_context():
+        db.session.remove()
+        db.drop_all()
         db.create_all()
         user = User(
             name='User Test',

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,106 @@
+import pytest
+from app import app
+from models import db, User, NotificationSettings
+
+
+def setup_users():
+    sa = User(
+        name='Super Admin',
+        first_name='Super',
+        last_name='Admin',
+        email='super@example.com',
+        role=User.ROLE_SUPERADMIN,
+        password_hash='x',
+        status='active',
+    )
+    ad = User(
+        name='Admin User',
+        first_name='Admin',
+        last_name='User',
+        email='admin@example.com',
+        role=User.ROLE_ADMIN,
+        password_hash='x',
+        status='active',
+    )
+    user = User(
+        name='Normal User',
+        first_name='Normal',
+        last_name='User',
+        email='user@example.com',
+        role=User.ROLE_USER,
+        password_hash='x',
+        status='active',
+    )
+    return sa, ad, user
+
+
+def test_admin_leaves_renders_checkboxes():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        sa, ad, user = setup_users()
+        db.session.add_all([sa, ad, user])
+        db.session.commit()
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['uid'] = sa.id
+        resp = client.get('/admin/leaves')
+        html = resp.data.decode('utf-8')
+        assert f'{sa.first_name} {sa.last_name}' in html
+        assert f'{ad.first_name} {ad.last_name}' in html
+        assert f'{user.first_name} {user.last_name}' not in html
+        db.drop_all()
+
+
+def test_new_request_notifies_selected_users(monkeypatch):
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        sa, ad, user = setup_users()
+        other = User(
+            name='Other Admin',
+            first_name='Other',
+            last_name='Admin',
+            email='other@example.com',
+            role=User.ROLE_ADMIN,
+            password_hash='x',
+            status='active',
+        )
+        db.session.add_all([sa, ad, other, user])
+        db.session.commit()
+        settings = NotificationSettings(notify_user_ids=[sa.id, ad.id])
+        db.session.add(settings)
+        db.session.commit()
+
+        sent = {}
+
+        def fake_send_mail(subject, body, recipients):
+            sent['recipients'] = set(recipients)
+
+        monkeypatch.setattr('app.send_mail_msmtp', fake_send_mail)
+
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['uid'] = user.id
+        data = {
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'start_at': '2024-01-01T10:00',
+            'end_at': '2024-01-01T12:00',
+            'purpose': '',
+            'carpool': '',
+            'carpool_with': '',
+            'notes': '',
+        }
+        client.post('/request/new', data=data, follow_redirects=True)
+        assert sent['recipients'] == {sa.email, ad.email}
+        assert other.email not in sent['recipients']
+        db.drop_all()


### PR DESCRIPTION
## Summary
- store notification recipient user IDs
- let superadmins pick recipients and send emails accordingly
- cover notification form and send logic with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b577e721288330b91f911d308530a9