### PR TITLE
Gestion des plages horaires de réservation

### DIFF
--- a/app.py
+++ b/app.py
@@ -16,7 +16,7 @@ from flask import (
     abort,
     send_file,
 )
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 from io import BytesIO
 from forms import (
     LoginForm,
@@ -219,10 +219,19 @@ def first_login():
 def new_request():
     form = NewRequestForm()
     if form.validate_on_submit():
+        if form.slot.data == "morning":
+            start_at = datetime.combine(form.date.data, time(8, 0))
+            end_at = datetime.combine(form.date.data, time(12, 0))
+        elif form.slot.data == "afternoon":
+            start_at = datetime.combine(form.date.data, time(13, 0))
+            end_at = datetime.combine(form.date.data, time(17, 0))
+        else:
+            start_at = datetime.combine(form.date.data, time(8, 0))
+            end_at = datetime.combine(form.date.data, time(17, 0))
         r = Reservation(
             user_id=current_user().id,
-            start_at=form.start_at.data,
-            end_at=form.end_at.data,
+            start_at=start_at,
+            end_at=end_at,
             purpose=form.purpose.data,
             carpool=form.carpool.data,
             carpool_with=form.carpool_with.data,

--- a/forms.py
+++ b/forms.py
@@ -5,7 +5,7 @@ from wtforms import (
     PasswordField,
     SubmitField,
     BooleanField,
-    DateTimeLocalField,
+    DateField,
     TextAreaField,
     SelectField,
     SelectMultipleField,
@@ -61,8 +61,16 @@ class RegisterForm(FlaskForm):
 class NewRequestForm(FlaskForm):
     first_name = StringField("Prénom", validators=[DataRequired(), Length(max=60)])
     last_name = StringField("Nom", validators=[DataRequired(), Length(max=60)])
-    start_at = DateTimeLocalField("Début", format="%Y-%m-%dT%H:%M", validators=[DataRequired()])
-    end_at = DateTimeLocalField("Fin", format="%Y-%m-%dT%H:%M", validators=[DataRequired()])
+    date = DateField("Date", format="%Y-%m-%d", validators=[DataRequired()])
+    slot = SelectField(
+        "Plage horaire",
+        choices=[
+            ("morning", "Matin"),
+            ("afternoon", "Après-midi"),
+            ("day", "Journée"),
+        ],
+        validators=[DataRequired()],
+    )
     purpose = StringField("Motif", validators=[Length(max=200)])
     carpool = BooleanField("Covoiturage")
     carpool_with = StringField("Avec qui")

--- a/templates/new_request.html
+++ b/templates/new_request.html
@@ -9,8 +9,8 @@
     <div class="col-md-6 mb-3">{{ form.last_name.label }} {{ form.last_name(class="form-control") }}</div>
   </div>
   <div class="row">
-    <div class="col-md-6 mb-3">{{ form.start_at.label }} {{ form.start_at(class="form-control") }}</div>
-    <div class="col-md-6 mb-3">{{ form.end_at.label }} {{ form.end_at(class="form-control") }}</div>
+    <div class="col-md-6 mb-3">{{ form.date.label }} {{ form.date(class="form-control") }}</div>
+    <div class="col-md-6 mb-3">{{ form.slot.label }} {{ form.slot(class="form-select") }}</div>
   </div>
   <div class="mb-3">{{ form.purpose.label }} {{ form.purpose(class="form-control") }}</div>
   <div class="form-check mb-3">{{ form.carpool(class="form-check-input") }} {{ form.carpool.label(class="form-check-label") }}</div>

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -93,8 +93,8 @@ def test_new_request_notifies_selected_users(monkeypatch):
         data = {
             'first_name': user.first_name,
             'last_name': user.last_name,
-            'start_at': '2024-01-01T10:00',
-            'end_at': '2024-01-01T12:00',
+            'date': '2024-01-01',
+            'slot': 'day',
             'purpose': '',
             'carpool': '',
             'carpool_with': '',


### PR DESCRIPTION
## Summary
- Remplace le choix de début/fin par un champ de date et une plage horaire.
- Calcule les datetimes de début et fin selon la plage sélectionnée avant d'enregistrer la réservation.
- Adapte les tests aux nouveaux champs.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c048e03c833096eb64789b8495aa