### PR TITLE
Support start and end slots for reservation requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -219,15 +219,22 @@ def first_login():
 def new_request():
     form = NewRequestForm()
     if form.validate_on_submit():
-        if form.slot.data == "morning":
-            start_at = datetime.combine(form.date.data, time(8, 0))
-            end_at = datetime.combine(form.date.data, time(12, 0))
-        elif form.slot.data == "afternoon":
-            start_at = datetime.combine(form.date.data, time(13, 0))
-            end_at = datetime.combine(form.date.data, time(17, 0))
-        else:
-            start_at = datetime.combine(form.date.data, time(8, 0))
-            end_at = datetime.combine(form.date.data, time(17, 0))
+        start_times = {
+            "morning": time(8, 0),
+            "afternoon": time(13, 0),
+            "day": time(8, 0),
+        }
+        end_times = {
+            "morning": time(12, 0),
+            "afternoon": time(17, 0),
+            "day": time(17, 0),
+        }
+        start_at = datetime.combine(
+            form.start_date.data, start_times[form.start_slot.data]
+        )
+        end_at = datetime.combine(
+            form.end_date.data, end_times[form.end_slot.data]
+        )
         r = Reservation(
             user_id=current_user().id,
             start_at=start_at,

--- a/forms.py
+++ b/forms.py
@@ -61,9 +61,19 @@ class RegisterForm(FlaskForm):
 class NewRequestForm(FlaskForm):
     first_name = StringField("Prénom", validators=[DataRequired(), Length(max=60)])
     last_name = StringField("Nom", validators=[DataRequired(), Length(max=60)])
-    date = DateField("Date", format="%Y-%m-%d", validators=[DataRequired()])
-    slot = SelectField(
-        "Plage horaire",
+    start_date = DateField("Date début", format="%Y-%m-%d", validators=[DataRequired()])
+    start_slot = SelectField(
+        "Créneau début",
+        choices=[
+            ("morning", "Matin"),
+            ("afternoon", "Après-midi"),
+            ("day", "Journée"),
+        ],
+        validators=[DataRequired()],
+    )
+    end_date = DateField("Date fin", format="%Y-%m-%d", validators=[DataRequired()])
+    end_slot = SelectField(
+        "Créneau fin",
         choices=[
             ("morning", "Matin"),
             ("afternoon", "Après-midi"),

--- a/templates/new_request.html
+++ b/templates/new_request.html
@@ -9,8 +9,12 @@
     <div class="col-md-6 mb-3">{{ form.last_name.label }} {{ form.last_name(class="form-control") }}</div>
   </div>
   <div class="row">
-    <div class="col-md-6 mb-3">{{ form.date.label }} {{ form.date(class="form-control") }}</div>
-    <div class="col-md-6 mb-3">{{ form.slot.label }} {{ form.slot(class="form-select") }}</div>
+    <div class="col-md-6 mb-3">{{ form.start_date.label }} {{ form.start_date(class="form-control") }}</div>
+    <div class="col-md-6 mb-3">{{ form.start_slot.label }} {{ form.start_slot(class="form-select") }}</div>
+  </div>
+  <div class="row">
+    <div class="col-md-6 mb-3">{{ form.end_date.label }} {{ form.end_date(class="form-control") }}</div>
+    <div class="col-md-6 mb-3">{{ form.end_slot.label }} {{ form.end_slot(class="form-select") }}</div>
   </div>
   <div class="mb-3">{{ form.purpose.label }} {{ form.purpose(class="form-control") }}</div>
   <div class="form-check mb-3">{{ form.carpool(class="form-check-input") }} {{ form.carpool.label(class="form-check-label") }}</div>

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -93,8 +93,10 @@ def test_new_request_notifies_selected_users(monkeypatch):
         data = {
             'first_name': user.first_name,
             'last_name': user.last_name,
-            'date': '2024-01-01',
-            'slot': 'day',
+            'start_date': '2024-01-01',
+            'start_slot': 'day',
+            'end_date': '2024-01-01',
+            'end_slot': 'day',
             'purpose': '',
             'carpool': '',
             'carpool_with': '',

--- a/tests/test_request_times.py
+++ b/tests/test_request_times.py
@@ -1,0 +1,45 @@
+import pytest
+from datetime import datetime
+from app import app
+from models import db, User, Reservation
+
+
+def test_new_request_creates_correct_datetimes():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        user = User(
+            name='Test User',
+            first_name='Test',
+            last_name='User',
+            email='test@example.com',
+            role=User.ROLE_USER,
+            password_hash='x',
+            status='active',
+        )
+        db.session.add(user)
+        db.session.commit()
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['uid'] = user.id
+        data = {
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'start_date': '2024-01-01',
+            'start_slot': 'afternoon',
+            'end_date': '2024-01-02',
+            'end_slot': 'morning',
+            'purpose': '',
+            'carpool': '',
+            'carpool_with': '',
+            'notes': '',
+        }
+        client.post('/request/new', data=data, follow_redirects=True)
+        r = Reservation.query.first()
+        assert r.start_at == datetime(2024, 1, 1, 13, 0)
+        assert r.end_at == datetime(2024, 1, 2, 12, 0)
+        db.drop_all()


### PR DESCRIPTION
## Summary
- Replace single date/slot with start_date/start_slot and end_date/end_slot
- Convert start/end date+slot pairs to datetimes when creating reservations
- Update templates and tests, including new coverage for slot conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c3c5f6f08330bac56b2012ac7a5a