### PR TITLE
Affiche les créneaux réservation par jour

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,6 +32,7 @@ from sqlalchemy.exc import IntegrityError
 import secrets
 from notify import send_mail_msmtp
 from flask_migrate import Migrate
+from utils import reservation_slot_label
 
 try:
     from weasyprint import HTML
@@ -606,6 +607,8 @@ def export_pdf_month():
         reservations=res,
         start=start,
         end=end,
+        slot_label=reservation_slot_label,
+        timedelta=timedelta,
     )
     pdf = HTML(string=html).write_pdf()
     return send_file(
@@ -637,6 +640,7 @@ def calendar_month():
         end=end,
         user=user,
         timedelta=timedelta,
+        slot_label=reservation_slot_label,
     )
 
 

--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -35,9 +35,9 @@
           {% for r in reservations if r.vehicle_id==v.id and r.start_at.date() <= day.date() <= r.end_at.date() %}
             {% set cell_has_res = true %}
             {% if user and user.role in ['admin', 'superadmin'] %}
-              <a href="{{ url_for('manage_request', rid=r.id) }}" class="badge bg-success">{{ r.user.name }}</a>
+              <a href="{{ url_for('manage_request', rid=r.id) }}" class="badge bg-success">{{ r.user.name }} ({{ slot_label(r, day) }})</a>
             {% else %}
-              <span class="badge bg-success">{{ r.user.name }}</span>
+              <span class="badge bg-success">{{ r.user.name }} ({{ slot_label(r, day) }})</span>
             {% endif %}
           {% endfor %}
           {% if not cell_has_res and user and user.role in ['admin', 'superadmin'] %}
@@ -49,7 +49,7 @@
     {% endfor %}
   </tbody>
 </table>
-<p class="text-muted">Légende : <span class="badge bg-success">Nom du réservant</span> = Réservé (approuvé)</p>
+<p class="text-muted">Légende : <span class="badge bg-success">Nom du réservant (Matin/Après-midi/Journée)</span> = Réservé (approuvé)</p>
 {% if user and user.role in ['admin', 'superadmin'] %}
   <a class="btn btn-outline-secondary" href="{{ url_for('export_pdf_month') }}">Exporter PDF du mois</a>
 {% endif %}

--- a/templates/pdf_month.html
+++ b/templates/pdf_month.html
@@ -21,7 +21,7 @@ th.sticky, td.sticky{position:sticky;left:0;background:#fff}
 {% set day = start + timedelta(days=i) %}
 <td>
 {% for r in reservations if r.vehicle_id==v.id and r.start_at.date() <= day.date() <= r.end_at.date() %}
-<span class="badge">R</span>
+<span class="badge">{{ slot_label(r, day) }}</span>
 {% endfor %}
 </td>
 {% endfor %}
@@ -29,5 +29,5 @@ th.sticky, td.sticky{position:sticky;left:0;background:#fff}
 {% endfor %}
 </tbody>
 </table>
-<p style="font-size:10px;color:#666;">Légende: R = Réservé (approuvé)</p>
+<p style="font-size:10px;color:#666;">Légende: Matin / Après-midi / Journée = Réservé (approuvé)</p>
 </body></html>

--- a/tests/test_reservation_slots.py
+++ b/tests/test_reservation_slots.py
@@ -1,0 +1,48 @@
+import os
+import sys
+from datetime import datetime, timedelta
+
+from flask import render_template
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app
+from models import Vehicle, Reservation, User
+from utils import reservation_slot_label
+
+
+def test_same_day_reservations_have_distinct_slots():
+    start = datetime(2024, 1, 1)
+    end = datetime(2024, 2, 1)
+    v = Vehicle(id=1, code='V1', label='Vehicule 1')
+    viewer = User(name='Viewer', first_name='View', last_name='Er', email='viewer@example.com', role=User.ROLE_USER, password_hash='x')
+    u1 = User(name='Alice', first_name='Alice', last_name='A', email='a@example.com', role=User.ROLE_USER, password_hash='x')
+    u2 = User(name='Bob', first_name='Bob', last_name='B', email='b@example.com', role=User.ROLE_USER, password_hash='x')
+    r1 = Reservation(vehicle_id=1, user_id=1, start_at=datetime(2024, 1, 10, 8, 0), end_at=datetime(2024, 1, 10, 12, 0))
+    r1.user = u1
+    r2 = Reservation(vehicle_id=1, user_id=2, start_at=datetime(2024, 1, 10, 13, 0), end_at=datetime(2024, 1, 10, 17, 0))
+    r2.user = u2
+    with app.test_request_context('/calendar/month'):
+        html = render_template(
+            'calendar_month.html',
+            vehicles=[v],
+            reservations=[r1, r2],
+            start=start,
+            end=end,
+            user=viewer,
+            timedelta=timedelta,
+            slot_label=reservation_slot_label,
+        )
+        pdf_html = render_template(
+            'pdf_month.html',
+            vehicles=[v],
+            reservations=[r1, r2],
+            start=start,
+            end=end,
+            slot_label=reservation_slot_label,
+            timedelta=timedelta,
+        )
+    assert 'Alice (Matin)' in html
+    assert 'Bob (Après-midi)' in html
+    assert 'Matin' in pdf_html
+    assert 'Après-midi' in pdf_html

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,29 @@
+from datetime import time
+
+def reservation_slot_label(reservation, day):
+    """Return a human label (Matin/Après-midi/Journée) for reservation on given day."""
+    morning_start = time(8, 0)
+    morning_end = time(12, 0)
+    afternoon_start = time(13, 0)
+    afternoon_end = time(17, 0)
+    day_date = day.date()
+    start_date = reservation.start_at.date()
+    end_date = reservation.end_at.date()
+    start_time = reservation.start_at.time()
+    end_time = reservation.end_at.time()
+
+    if start_date == day_date and end_date == day_date:
+        if start_time == morning_start and end_time == morning_end:
+            return "Matin"
+        if start_time == afternoon_start and end_time == afternoon_end:
+            return "Après-midi"
+        return "Journée"
+    if start_date == day_date:
+        if start_time >= afternoon_start:
+            return "Après-midi"
+        return "Journée"
+    if end_date == day_date:
+        if end_time <= morning_end:
+            return "Matin"
+        return "Journée"
+    return "Journée"


### PR DESCRIPTION
## Summary
- Ajout d'une fonction utilitaire `reservation_slot_label` pour déterminer le créneau (matin, après-midi, journée) d'une réservation sur un jour donné.
- Affichage des créneaux dans la vue mensuelle et dans l'export PDF, avec mise à jour des légendes.
- Couverture de tests pour vérifier la distinction entre créneaux sur une même journée.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6e1420de083309b9e6a91dabefa5e