### PR TITLE
Block pending users from submitting requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,7 +94,14 @@ def __ping__():
 @app.before_request
 def _force_login():
     p = request.path or "/"
-    public = {"/login", "/first_login", "/__ping__"}
+    public = {
+        "/login",
+        "/first_login",
+        "/logout",
+        "/__ping__",
+        "/home",
+        "/",
+    }
     if p in public or p.startswith("/static/"):
         return None
     if not session.get("uid"):
@@ -102,6 +109,10 @@ def _force_login():
         return redirect(
             "/login" + (f"?next={_urlquote(nxt)}" if nxt else "")
         )
+    u = current_user()
+    if not u or u.status != "active":
+        flash("Compte non activé", "danger")
+        return redirect(url_for("home"))
     return None
 
 
@@ -218,6 +229,10 @@ def first_login():
 
 @app.route("/request/new", methods=["GET", "POST"])
 def new_request():
+    u = current_user()
+    if not u or u.status != "active":
+        flash("Compte non activé", "danger")
+        return redirect(url_for("home"))
     form = NewRequestForm()
     if form.validate_on_submit():
         start_times = {

--- a/tests/test_calendar_month_nav.py
+++ b/tests/test_calendar_month_nav.py
@@ -51,6 +51,7 @@ def test_calendar_month_params_interpreted():
             email='user@example.com',
             role=User.ROLE_USER,
             password_hash='x',
+            status='active',
         )
         db.session.add(user)
         db.session.commit()

--- a/tests/test_pending_user_request.py
+++ b/tests/test_pending_user_request.py
@@ -1,0 +1,43 @@
+import pytest
+from app import app
+from models import db, User, Reservation
+
+
+def test_pending_user_cannot_create_request():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        user = User(
+            name='Pending User',
+            first_name='Pending',
+            last_name='User',
+            email='pending@example.com',
+            role=User.ROLE_USER,
+            password_hash='x',
+            status='pending',
+        )
+        db.session.add(user)
+        db.session.commit()
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['uid'] = user.id
+        data = {
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'start_date': '2024-01-01',
+            'start_slot': 'morning',
+            'end_date': '2024-01-01',
+            'end_slot': 'morning',
+            'purpose': '',
+            'carpool': '',
+            'carpool_with': '',
+            'notes': '',
+        }
+        resp = client.post('/request/new', data=data)
+        assert resp.status_code in (302, 403)
+        assert Reservation.query.count() == 0
+        db.drop_all()

--- a/tests/test_vehicle_admin.py
+++ b/tests/test_vehicle_admin.py
@@ -16,6 +16,7 @@ def client():
             email='admin@example.com',
             role=User.ROLE_ADMIN,
             password_hash='x',
+            status='active',
         )
         db.session.add(admin)
         db.session.commit()


### PR DESCRIPTION
## Summary
- Ensure before-request guard rejects non-active users
- Prevent pending users from posting new reservation requests
- Cover pending user scenario with tests and update existing tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6e5b02c30833085fad1d3ba618b90