### PR TITLE
Activate seeded admin accounts

### DIFF
--- a/seed.py
+++ b/seed.py
@@ -22,12 +22,14 @@ with app.app_context():
         name="Super Admin",
         email="gestionvehiculestomer@gmail.com",
         role=User.ROLE_SUPERADMIN,
+        status="active",
     )
     super_admin.set_password("Sophieestaires59940")
     admin = User(
         name="Administrateur",
         email="alexandre.stephen@free.fr",
         role=User.ROLE_ADMIN,
+        status="active",
     )
     admin.set_password("Sophieestaires")
     db.session.add_all([super_admin, admin])


### PR DESCRIPTION
## Summary
- Ensure super_admin and admin users are created with `status="active"` in the seed script

## Testing
- `pytest -q`
- `python seed.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6f5e2ed38833082d787c78858c1d1