### PR TITLE
Make end date optional in request form

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -10,7 +10,7 @@ from wtforms import (
     SelectField,
     SelectMultipleField,
 )
-from wtforms.validators import DataRequired, Email, Length, EqualTo
+from wtforms.validators import DataRequired, Email, Length, EqualTo, Optional
 from wtforms.widgets import CheckboxInput, ListWidget
 from models import User
 
@@ -71,7 +71,7 @@ class NewRequestForm(FlaskForm):
         ],
         validators=[DataRequired()],
     )
-    end_date = DateField("Date fin", format="%Y-%m-%d", validators=[DataRequired()])
+    end_date = DateField("Date fin (si plusieurs jours)", format="%Y-%m-%d", validators=[Optional()])
     end_slot = SelectField(
         "Créneau fin",
         choices=[


### PR DESCRIPTION
## Summary
- allow NewRequestForm's end_date to be optional with an updated label

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6faf8205c83308168054b9411377a