### PR TITLE
Use start date as default end date for new requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -245,11 +245,13 @@ def new_request():
             "afternoon": time(17, 0),
             "day": time(17, 0),
         }
+        end_date = form.end_date.data or form.start_date.data
+        end_slot = form.end_slot.data or form.start_slot.data
         start_at = datetime.combine(
             form.start_date.data, start_times[form.start_slot.data]
         )
         end_at = datetime.combine(
-            form.end_date.data, end_times[form.end_slot.data]
+            end_date, end_times[end_slot]
         )
         r = Reservation(
             user_id=current_user().id,


### PR DESCRIPTION
## Summary
- Default reservation end date to the start date when none is provided
- Fallback to the start slot if no end slot is given
- Compute end datetime using these defaults in /request/new

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fba94868833083dbb96401f9a827