### PR TITLE
Add test for end-slot when end-date missing

### DIFF
--- a/tests/test_request_times.py
+++ b/tests/test_request_times.py
@@ -43,3 +43,43 @@ def test_new_request_creates_correct_datetimes():
         assert r.start_at == datetime(2024, 1, 1, 13, 0)
         assert r.end_at == datetime(2024, 1, 2, 12, 0)
         db.drop_all()
+
+
+def test_new_request_without_end_date_uses_start_date_and_end_slot_time():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        user = User(
+            name='Test User',
+            first_name='Test',
+            last_name='User',
+            email='test@example.com',
+            role=User.ROLE_USER,
+            password_hash='x',
+            status='active',
+        )
+        db.session.add(user)
+        db.session.commit()
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['uid'] = user.id
+        data = {
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'start_date': '2024-01-01',
+            'start_slot': 'morning',
+            'end_slot': 'afternoon',
+            'purpose': '',
+            'carpool': '',
+            'carpool_with': '',
+            'notes': '',
+        }
+        client.post('/request/new', data=data, follow_redirects=True)
+        r = Reservation.query.first()
+        assert r.start_at == datetime(2024, 1, 1, 8, 0)
+        assert r.end_at == datetime(2024, 1, 1, 17, 0)
+        db.drop_all()


### PR DESCRIPTION
## Summary
- test reservation end time uses start date when no end date provided

## Testing
- `PYTHONPATH=. pytest tests/test_request_times.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6fc64bacc83308e3b068ffd8082ea