### PR TITLE
Display time slots in reservation management

### DIFF
--- a/app.py
+++ b/app.py
@@ -524,6 +524,7 @@ def admin_reservations():
         reservations=res,
         user=user,
         current_user=user,
+        slot_label=reservation_slot_label,
     )
 
 
@@ -599,6 +600,7 @@ def manage_request(rid):
         availability=avail,
         user=user,
         current_user=user,
+        slot_label=reservation_slot_label,
     )
 
 

--- a/templates/admin_reservations.html
+++ b/templates/admin_reservations.html
@@ -9,8 +9,8 @@
     <tr>
       <td>{{ r.id }}</td>
       <td>{{ r.vehicle.code if r.vehicle else "A AFFECTER" }}</td>
-      <td>{{ r.start_at|dt }}</td>
-      <td>{{ r.end_at|dt }}</td>
+      <td>{{ r.start_at.strftime('%d/%m/%Y') }} {{ slot_label(r, r.start_at) }}</td>
+      <td>{% if r.start_at.date() != r.end_at.date() %}{{ r.end_at.strftime('%d/%m/%Y') }} {{ slot_label(r, r.end_at) }}{% endif %}</td>
       <td>{{ r.user.name }}</td>
       <td>
         {% if r.status=='approved' %}<span class="badge bg-success">approuvée</span>

--- a/templates/manage_request.html
+++ b/templates/manage_request.html
@@ -4,7 +4,11 @@
 
 <div class="card mb-3">
   <div class="card-body">
-    <p><strong>Période :</strong> {{ r.start_at|dt }} → {{ r.end_at|dt }}</p>
+    {% if r.start_at.date() != r.end_at.date() %}
+    <p><strong>Période :</strong> {{ r.start_at.strftime('%d/%m/%Y') }} {{ slot_label(r, r.start_at) }} → {{ r.end_at.strftime('%d/%m/%Y') }} {{ slot_label(r, r.end_at) }}</p>
+    {% else %}
+    <p><strong>Période :</strong> {{ r.start_at.strftime('%d/%m/%Y') }} {{ slot_label(r, r.start_at) }}</p>
+    {% endif %}
     <p><strong>Motif :</strong> {{ r.purpose or '—' }}</p>
     <p><strong>Covoiturage :</strong> {% if r.carpool %}Oui ({{ r.carpool_with or '—' }}){% else %}Non{% endif %}</p>
     <p><strong>Précisions :</strong> {{ r.notes or '—' }}</p>


### PR DESCRIPTION
## Summary
- show Matin/Après-midi/Journée slots in admin reservation lists and details
- hide end date when reservation covers a single day

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b70140c92483308bfe2b7e63b1f3d2