### PR TITLE
Allow time range matching for reservation slots

### DIFF
--- a/tests/test_reservation_slots.py
+++ b/tests/test_reservation_slots.py
@@ -46,3 +46,14 @@ def test_same_day_reservations_have_distinct_slots():
     assert 'Bob (Après-midi)' in html
     assert 'Matin' in pdf_html
     assert 'Après-midi' in pdf_html
+
+
+def test_partial_afternoon_reservation_is_labelled_afternoon():
+    reservation = Reservation(
+        vehicle_id=1,
+        user_id=1,
+        start_at=datetime(2024, 1, 10, 13, 0),
+        end_at=datetime(2024, 1, 10, 16, 59),
+    )
+    day = datetime(2024, 1, 10)
+    assert reservation_slot_label(reservation, day) == "Après-midi"

--- a/utils.py
+++ b/utils.py
@@ -13,9 +13,9 @@ def reservation_slot_label(reservation, day):
     end_time = reservation.end_at.time()
 
     if start_date == day_date and end_date == day_date:
-        if start_time == morning_start and end_time == morning_end:
+        if start_time >= morning_start and end_time <= morning_end:
             return "Matin"
-        if start_time == afternoon_start and end_time == afternoon_end:
+        if start_time >= afternoon_start and end_time <= afternoon_end:
             return "Après-midi"
         return "Journée"
     if start_date == day_date:


### PR DESCRIPTION
## Summary
- Support time range comparisons for morning and afternoon reservations
- Test that partial afternoon reservations are labeled accordingly

## Testing
- `pytest tests/test_reservation_slots.py`


------
https://chatgpt.com/codex/tasks/task_e_68b70769f4d4833093563ee22947bc39