### PR TITLE
Verify morning slots start before noon

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -13,7 +13,11 @@ def reservation_slot_label(reservation, day):
     end_time = reservation.end_at.time()
 
     if start_date == day_date and end_date == day_date:
-        if start_time >= morning_start and end_time <= morning_end:
+        if (
+            start_time >= morning_start
+            and start_time <= morning_end
+            and end_time <= morning_end
+        ):
             return "Matin"
         if start_time >= afternoon_start and end_time <= afternoon_end:
             return "Après-midi"


### PR DESCRIPTION
## Summary
- ensure morning slot is selected only when a reservation starts and ends before noon

## Testing
- `pytest tests/test_reservation_slots.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b711a36a448330b2649e9894852d6d