### PR TITLE
Validate reservation times

### DIFF
--- a/app.py
+++ b/app.py
@@ -253,6 +253,9 @@ def new_request():
         end_at = datetime.combine(
             end_date, end_times[end_slot]
         )
+        if end_at <= start_at:
+            flash("La date de fin doit être postérieure à la date de début", "danger")
+            return render_template("new_request.html", form=form, user=current_user()), 200
         r = Reservation(
             user_id=current_user().id,
             start_at=start_at,

--- a/tests/test_request_times.py
+++ b/tests/test_request_times.py
@@ -83,3 +83,43 @@ def test_new_request_without_end_date_uses_start_date_and_end_slot_time():
         assert r.start_at == datetime(2024, 1, 1, 8, 0)
         assert r.end_at == datetime(2024, 1, 1, 17, 0)
         db.drop_all()
+
+
+def test_new_request_with_end_before_start_shows_error():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        user = User(
+            name='Test User',
+            first_name='Test',
+            last_name='User',
+            email='test@example.com',
+            role=User.ROLE_USER,
+            password_hash='x',
+            status='active',
+        )
+        db.session.add(user)
+        db.session.commit()
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['uid'] = user.id
+        data = {
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'start_date': '2024-01-02',
+            'start_slot': 'morning',
+            'end_date': '2024-01-01',
+            'end_slot': 'afternoon',
+            'purpose': '',
+            'carpool': '',
+            'carpool_with': '',
+            'notes': '',
+        }
+        resp = client.post('/request/new', data=data, follow_redirects=True)
+        assert "La date de fin doit être postérieure à la date de début" in resp.get_data(as_text=True)
+        assert Reservation.query.count() == 0
+        db.drop_all()


### PR DESCRIPTION
## Summary
- validate that end time is after start time when creating reservations
- test reservation creation fails when end precedes start

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71273e78083308e58fc6be681c1b3