### PR TITLE
Default end slot to start slot

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -87,6 +87,11 @@ class NewRequestForm(FlaskForm):
     notes = TextAreaField("Précisions", validators=[Length(max=1000)])
     submit = SubmitField("Envoyer la demande")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.end_slot.data:
+            self.end_slot.data = self.start_slot.data
+
 
 class UserForm(FlaskForm):
     first_name = StringField("Prénom", validators=[DataRequired(), Length(max=60)])

--- a/tests/test_request_times.py
+++ b/tests/test_request_times.py
@@ -85,6 +85,45 @@ def test_new_request_without_end_date_uses_start_date_and_end_slot_time():
         db.drop_all()
 
 
+def test_new_request_without_end_slot_defaults_to_start_slot():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        user = User(
+            name='Test User',
+            first_name='Test',
+            last_name='User',
+            email='test@example.com',
+            role=User.ROLE_USER,
+            password_hash='x',
+            status='active',
+        )
+        db.session.add(user)
+        db.session.commit()
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['uid'] = user.id
+        data = {
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'start_date': '2024-01-01',
+            'start_slot': 'afternoon',
+            'purpose': '',
+            'carpool': '',
+            'carpool_with': '',
+            'notes': '',
+        }
+        client.post('/request/new', data=data, follow_redirects=True)
+        r = Reservation.query.first()
+        assert r.start_at == datetime(2024, 1, 1, 13, 0)
+        assert r.end_at == datetime(2024, 1, 1, 17, 0)
+        db.drop_all()
+
+
 def test_new_request_with_end_before_start_shows_error():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     app.config['TESTING'] = True


### PR DESCRIPTION
## Summary
- Automatically set `end_slot` to `start_slot` in `NewRequestForm` when missing
- Add regression test ensuring missing end slot mirrors start slot

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7135d80b88330aaa79852f60a84be