### PR TITLE
Handle optional end date and slot in reservation form

### DIFF
--- a/app.py
+++ b/app.py
@@ -245,6 +245,7 @@ def new_request():
             "afternoon": time(17, 0),
             "day": time(17, 0),
         }
+        # Utiliser la date/slot de début si ceux de fin ne sont pas fournis
         end_date = form.end_date.data or form.start_date.data
         end_slot = form.end_slot.data or form.start_slot.data
         start_at = datetime.combine(

--- a/forms.py
+++ b/forms.py
@@ -71,7 +71,12 @@ class NewRequestForm(FlaskForm):
         ],
         validators=[DataRequired()],
     )
-    end_date = DateField("Date fin (si plusieurs jours)", format="%Y-%m-%d", validators=[Optional()])
+    end_date = DateField(
+        "Date fin (si plusieurs jours)",
+        format="%Y-%m-%d",
+        validators=[Optional()],
+        render_kw={"required": False},
+    )
     end_slot = SelectField(
         "Créneau fin",
         choices=[
@@ -79,18 +84,13 @@ class NewRequestForm(FlaskForm):
             ("afternoon", "Après-midi"),
             ("day", "Journée"),
         ],
-        validators=[DataRequired()],
+        validators=[Optional()],
     )
     purpose = StringField("Motif", validators=[Length(max=200)])
     carpool = BooleanField("Covoiturage")
     carpool_with = StringField("Avec qui")
     notes = TextAreaField("Précisions", validators=[Length(max=1000)])
     submit = SubmitField("Envoyer la demande")
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if not self.end_slot.data:
-            self.end_slot.data = self.start_slot.data
 
 
 class UserForm(FlaskForm):

--- a/templates/new_request.html
+++ b/templates/new_request.html
@@ -12,7 +12,14 @@
     <div class="col-md-6 mb-3">{{ form.start_date.label }} {{ form.start_date(class="form-control") }}</div>
     <div class="col-md-6 mb-3">{{ form.start_slot.label }} {{ form.start_slot(class="form-select") }}</div>
   </div>
-  <div class="row">
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" id="multiDay">
+    <label class="form-check-label" for="multiDay">
+      Réservation sur plusieurs jours
+    </label>
+  </div>
+  <div class="form-text mb-3">La date de fin est uniquement nécessaire pour les réservations de plusieurs jours.</div>
+  <div id="end_fields" class="row" style="display: none;">
     <div class="col-md-6 mb-3">{{ form.end_date.label }} {{ form.end_date(class="form-control") }}</div>
     <div class="col-md-6 mb-3">{{ form.end_slot.label }} {{ form.end_slot(class="form-select") }}</div>
   </div>
@@ -22,4 +29,13 @@
   <div class="mb-3">{{ form.notes.label }} {{ form.notes(class="form-control", rows=3) }}</div>
   {{ form.submit(class="btn btn-success") }}
 </form>
+<script>
+  const multiDay = document.getElementById('multiDay');
+  const endFields = document.getElementById('end_fields');
+  function toggleEndFields() {
+    endFields.style.display = multiDay.checked ? 'flex' : 'none';
+  }
+  multiDay.addEventListener('change', toggleEndFields);
+  toggleEndFields();
+</script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Make end slot optional and avoid HTML `required` on end date
- Handle missing end information in `new_request` view
- Explain multi-day reservations and toggle end date fields in the form

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b716da6fe88330890df3bf2f8229b7