### PR TITLE
Handle optional end slot in reservation form

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -80,10 +80,12 @@ class NewRequestForm(FlaskForm):
     end_slot = SelectField(
         "Créneau fin",
         choices=[
+            ("", "—"),
             ("morning", "Matin"),
             ("afternoon", "Après-midi"),
             ("day", "Journée"),
         ],
+        default="",
         validators=[Optional()],
     )
     purpose = StringField("Motif", validators=[Length(max=200)])

--- a/templates/new_request.html
+++ b/templates/new_request.html
@@ -32,8 +32,16 @@
 <script>
   const multiDay = document.getElementById('multiDay');
   const endFields = document.getElementById('end_fields');
+  const endDateInput = document.getElementById('end_date');
+  const endSlotSelect = document.getElementById('end_slot');
   function toggleEndFields() {
-    endFields.style.display = multiDay.checked ? 'flex' : 'none';
+    const enabled = multiDay.checked;
+    endFields.style.display = enabled ? 'flex' : 'none';
+    endDateInput.disabled = endSlotSelect.disabled = !enabled;
+    if (!enabled) {
+      endDateInput.value = '';
+      endSlotSelect.value = '';
+    }
   }
   multiDay.addEventListener('change', toggleEndFields);
   toggleEndFields();

--- a/tests/test_request_times.py
+++ b/tests/test_request_times.py
@@ -124,6 +124,47 @@ def test_new_request_without_end_slot_defaults_to_start_slot():
         db.drop_all()
 
 
+def test_new_request_with_empty_end_slot_string_creates_reservation():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        user = User(
+            name='Test User',
+            first_name='Test',
+            last_name='User',
+            email='test@example.com',
+            role=User.ROLE_USER,
+            password_hash='x',
+            status='active',
+        )
+        db.session.add(user)
+        db.session.commit()
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['uid'] = user.id
+        data = {
+            'first_name': user.first_name,
+            'last_name': user.last_name,
+            'start_date': '2024-01-01',
+            'start_slot': 'afternoon',
+            'end_slot': '',
+            'purpose': '',
+            'carpool': '',
+            'carpool_with': '',
+            'notes': '',
+        }
+        resp = client.post('/request/new', data=data, follow_redirects=True)
+        assert "La date de fin doit être postérieure à la date de début" not in resp.get_data(as_text=True)
+        r = Reservation.query.first()
+        assert r.start_at == datetime(2024, 1, 1, 13, 0)
+        assert r.end_at == datetime(2024, 1, 1, 17, 0)
+        db.drop_all()
+
+
 def test_new_request_with_end_before_start_shows_error():
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
     app.config['TESTING'] = True


### PR DESCRIPTION
## Summary
- Allow end time to be left blank by adding empty choice and default in `NewRequestForm`
- Disable end date/slot fields unless multi-day reservation is selected and clear their values when hidden
- Test submitting a request with an empty end slot string

## Testing
- `PYTHONPATH=. pytest tests/test_request_times.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b719f63a50833097b29a51d7f34f14