### PR TITLE
Support reservation segments and conflict handling

### DIFF
--- a/models.py
+++ b/models.py
@@ -48,6 +48,21 @@ class Reservation(db.Model):
     user = db.relationship("User", backref="reservations")
 
 
+class ReservationSegment(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    reservation_id = db.Column(
+        db.Integer, db.ForeignKey('reservation.id'), nullable=False
+    )
+    vehicle_id = db.Column(
+        db.Integer, db.ForeignKey('vehicle.id'), nullable=False
+    )
+    start_at = db.Column(db.DateTime, nullable=False)
+    end_at = db.Column(db.DateTime, nullable=False)
+
+    reservation = db.relationship('Reservation', backref='segments')
+    vehicle = db.relationship('Vehicle')
+
+
 class NotificationSettings(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     notify_superadmin = db.Column(db.Boolean, default=False)

--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -36,9 +36,28 @@
             {% set cell_has_res = true %}
             {% if user and user.role in ['admin', 'superadmin'] %}
               <a href="{{ url_for('manage_request', rid=r.id) }}" class="badge bg-success">{{ r.user.name }} ({{ slot_label(r, day) }})</a>
+              <form method="post" action="{{ url_for('manage_request', rid=r.id) }}" class="mt-1">
+                <input type="hidden" name="action" value="segment">
+                <input type="hidden" name="start_at" value="{{ r.start_at.isoformat() }}">
+                <input type="hidden" name="end_at" value="{{ r.end_at.isoformat() }}">
+                <div class="input-group input-group-sm">
+                  <select name="vehicle_id" class="form-select form-select-sm">
+                    {% for veh in vehicles %}
+                      {% if veh.id != v.id %}
+                        <option value="{{ veh.id }}">{{ veh.code }}</option>
+                      {% endif %}
+                    {% endfor %}
+                  </select>
+                  <button class="btn btn-outline-secondary" type="submit">Segment</button>
+                </div>
+              </form>
             {% else %}
               <span class="badge bg-success">{{ r.user.name }} ({{ slot_label(r, day) }})</span>
             {% endif %}
+          {% endfor %}
+          {% for s in segments if s.vehicle_id==v.id and s.start_at.date() <= day.date() <= s.end_at.date() %}
+            {% set cell_has_res = true %}
+            <span class="badge bg-primary">{{ s.reservation.user.name }} ({{ slot_label(s, day) }})</span>
           {% endfor %}
           {% if not cell_has_res and user and user.role in ['admin', 'superadmin'] %}
             <a href="{{ url_for('new_request') }}" class="d-block w-100 h-100 text-decoration-none">&nbsp;</a>

--- a/templates/manage_request.html
+++ b/templates/manage_request.html
@@ -41,4 +41,32 @@
   <button name="action" value="approve" class="btn btn-success">Approuver avec ce véhicule</button>
   <button name="action" value="reject"  class="btn btn-outline-danger">Refuser</button>
 </form>
+
+<hr/>
+<h2 class="h6">Diviser la réservation</h2>
+<form method="post" class="row g-2">
+  <div class="col-md-4">
+    <label class="form-label">Véhicule segment 1</label>
+    <select name="vehicle_id1" class="form-select" required>
+      {% for v, _ in availability %}
+        <option value="{{ v.id }}">{{ v.code }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-md-4">
+    <label class="form-label">Heure de coupure</label>
+    <input type="datetime-local" name="split_at" class="form-control" required>
+  </div>
+  <div class="col-md-4">
+    <label class="form-label">Véhicule segment 2</label>
+    <select name="vehicle_id2" class="form-select" required>
+      {% for v, _ in availability %}
+        <option value="{{ v.id }}">{{ v.code }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-12">
+    <button name="action" value="split" class="btn btn-primary mt-2">Créer les segments</button>
+  </div>
+</form>
 {% endblock %}

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import pytest
+from datetime import datetime, timedelta
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app, vehicles_availability
+from models import db, User, Vehicle, Reservation, ReservationSegment
+from utils import reservation_slot_label
+from flask import render_template
+
+
+@pytest.fixture
+def app_ctx():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        yield
+        db.drop_all()
+
+
+def create_user(role=User.ROLE_USER):
+    u = User(
+        name='User',
+        first_name='U',
+        last_name='Ser',
+        email=f'user{role}@example.com',
+        role=role,
+        password_hash='x',
+        status='active',
+    )
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def test_split_creates_segments(app_ctx):
+    admin = create_user(role=User.ROLE_ADMIN)
+    normal = create_user(role=User.ROLE_USER)
+    v1 = Vehicle(code='V1', label='Vehicule 1')
+    v2 = Vehicle(code='V2', label='Vehicule 2')
+    db.session.add_all([v1, v2])
+    db.session.commit()
+    r = Reservation(user_id=normal.id, start_at=datetime(2024,1,1,8), end_at=datetime(2024,1,1,16))
+    db.session.add(r)
+    db.session.commit()
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['uid'] = admin.id
+    data = {
+        'action': 'split',
+        'split_at': '2024-01-01T12:00:00',
+        'vehicle_id1': str(v1.id),
+        'vehicle_id2': str(v2.id),
+    }
+    client.post(f'/admin/manage/{r.id}', data=data)
+    segs = ReservationSegment.query.filter_by(reservation_id=r.id).order_by(ReservationSegment.start_at).all()
+    assert len(segs) == 2
+    assert segs[0].vehicle_id == v1.id
+    assert segs[0].start_at == datetime(2024,1,1,8)
+    assert segs[0].end_at == datetime(2024,1,1,12)
+    assert segs[1].vehicle_id == v2.id
+    assert segs[1].start_at == datetime(2024,1,1,12)
+    assert segs[1].end_at == datetime(2024,1,1,16)
+    assert r.vehicle_id is None
+
+
+def test_split_conflict_detection(app_ctx):
+    admin = create_user(role=User.ROLE_ADMIN)
+    user1 = create_user()
+    v1 = Vehicle(code='V1', label='Vehicule 1')
+    v2 = Vehicle(code='V2', label='Vehicule 2')
+    db.session.add_all([v1, v2])
+    db.session.commit()
+    existing = Reservation(user_id=user1.id, vehicle_id=v1.id,
+                           start_at=datetime(2024,1,1,10), end_at=datetime(2024,1,1,12), status='approved')
+    db.session.add(existing)
+    r = Reservation(user_id=user1.id, start_at=datetime(2024,1,1,9), end_at=datetime(2024,1,1,13))
+    db.session.add(r)
+    db.session.commit()
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['uid'] = admin.id
+    data = {
+        'action': 'split',
+        'split_at': '2024-01-01T11:00:00',
+        'vehicle_id1': str(v1.id),
+        'vehicle_id2': str(v2.id),
+    }
+    client.post(f'/admin/manage/{r.id}', data=data)
+    segs = ReservationSegment.query.filter_by(reservation_id=r.id).all()
+    assert segs == []
+
+
+def test_vehicle_availability_with_segments(app_ctx):
+    v1 = Vehicle(code='V1', label='Vehicule 1')
+    v2 = Vehicle(code='V2', label='Vehicule 2')
+    db.session.add_all([v1, v2])
+    u = create_user()
+    r = Reservation(user_id=u.id, start_at=datetime(2024,1,1,8), end_at=datetime(2024,1,1,12), status='approved')
+    db.session.add(r)
+    db.session.commit()
+    seg = ReservationSegment(reservation_id=r.id, vehicle_id=v1.id,
+                             start_at=datetime(2024,1,1,8), end_at=datetime(2024,1,1,12))
+    db.session.add(seg)
+    db.session.commit()
+    avail = dict((v.id, free) for v, free in vehicles_availability(datetime(2024,1,1,9), datetime(2024,1,1,10)))
+    assert avail[v1.id] is False
+    assert avail[v2.id] is True
+
+
+def test_calendar_month_has_segment_form(app_ctx):
+    admin = create_user(role=User.ROLE_ADMIN)
+    v1 = Vehicle(code='V1', label='Vehicule 1')
+    v2 = Vehicle(code='V2', label='Vehicule 2')
+    db.session.add_all([v1, v2])
+    u = create_user()
+    r = Reservation(vehicle_id=v1.id, user_id=u.id, start_at=datetime(2024,1,10,8), end_at=datetime(2024,1,10,12), status='approved')
+    db.session.add(r)
+    db.session.commit()
+    with app.test_request_context('/calendar/month'):
+        html = render_template('calendar_month.html', vehicles=[v1, v2], reservations=[r], segments=[], start=datetime(2024,1,1), end=datetime(2024,2,1), user=admin, timedelta=timedelta, slot_label=reservation_slot_label)
+    assert 'name="vehicle_id"' in html


### PR DESCRIPTION
## Summary
- allow splitting reservations into multiple vehicle segments
- add conflict checks for segments and expose segment creation in admin UI and calendar
- display segment-aware availability and provide tests for segment management

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b97cb8bc7483309f21baddac63b263