### PR TITLE
Allow day-based reservation segments

### DIFF
--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -35,22 +35,7 @@
           {% for r in reservations if r.vehicle_id==v.id and r.start_at.date() <= day.date() <= r.end_at.date() %}
             {% set cell_has_res = true %}
             {% if user and user.role in ['admin', 'superadmin'] %}
-              <a href="{{ url_for('manage_request', rid=r.id) }}" class="badge bg-success">{{ r.user.name }} ({{ slot_label(r, day) }})</a>
-              <form method="post" action="{{ url_for('manage_request', rid=r.id) }}" class="mt-1">
-                <input type="hidden" name="action" value="segment">
-                <input type="hidden" name="start_at" value="{{ r.start_at.isoformat() }}">
-                <input type="hidden" name="end_at" value="{{ r.end_at.isoformat() }}">
-                <div class="input-group input-group-sm">
-                  <select name="vehicle_id" class="form-select form-select-sm">
-                    {% for veh in vehicles %}
-                      {% if veh.id != v.id %}
-                        <option value="{{ veh.id }}">{{ veh.code }}</option>
-                      {% endif %}
-                    {% endfor %}
-                  </select>
-                  <button class="btn btn-outline-secondary" type="submit">Segment</button>
-                </div>
-              </form>
+              <a href="{{ url_for('manage_request', rid=r.id, day=day.strftime('%Y-%m-%d')) }}" class="badge bg-success">{{ r.user.name }} ({{ slot_label(r, day) }})</a>
             {% else %}
               <span class="badge bg-success">{{ r.user.name }} ({{ slot_label(r, day) }})</span>
             {% endif %}

--- a/templates/manage_request.html
+++ b/templates/manage_request.html
@@ -42,6 +42,24 @@
   <button name="action" value="reject"  class="btn btn-outline-danger">Refuser</button>
 </form>
 
+{% if day %}
+<hr/>
+<h2 class="h6">Segmenter la journée du {{ day.strftime('%d/%m/%Y') }}</h2>
+<form method="post" class="row g-2">
+  <div class="col-md-6">
+    <label class="form-label">Véhicule</label>
+    <select name="vehicle_id" class="form-select" required>
+      {% for v, free in availability %}
+        <option value="{{ v.id }}" {% if not free %}disabled{% endif %}>{{ v.code }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-12">
+    <button name="action" value="segment_day" class="btn btn-primary mt-2">Attribuer ce véhicule</button>
+  </div>
+</form>
+{% endif %}
+
 <hr/>
 <h2 class="h6">Diviser la réservation</h2>
 <form method="post" class="row g-2">


### PR DESCRIPTION
## Summary
- Link calendar cells to manage requests with the targeted day
- Support day-specific vehicle segments in `manage_request`
- Add UI and tests for day-based reservation segments

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9842699f883309c2ea15a1f46264a