### PR TITLE
Adjust segment boundaries to exclude selected day

### DIFF
--- a/app.py
+++ b/app.py
@@ -630,14 +630,14 @@ def manage_request(rid):
                         reservation_id=r.id,
                         vehicle_id=original_vehicle_id,
                         start_at=r.start_at,
-                        end_at=day_start,
+                        end_at=day_start - timedelta(microseconds=1),
                     )
                     db.session.add(before_seg)
                 if day_end < r.end_at:
                     after_seg = ReservationSegment(
                         reservation_id=r.id,
                         vehicle_id=original_vehicle_id,
-                        start_at=day_end,
+                        start_at=day_end + timedelta(microseconds=1),
                         end_at=r.end_at,
                     )
                     db.session.add(after_seg)

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -152,11 +152,11 @@ def test_segment_day_creates_segment(app_ctx):
     seg_before, seg_day, seg_after = segs
     assert seg_before.vehicle_id == v1.id
     assert seg_before.start_at == datetime(2024,1,1,8)
-    assert seg_before.end_at.date() == datetime(2024,1,2).date()
+    assert seg_before.end_at == datetime(2024,1,1,23,59,59,999999)
     assert seg_day.vehicle_id == v2.id
     assert seg_day.start_at.date() == datetime(2024,1,2).date()
     assert seg_day.end_at.date() == datetime(2024,1,2).date()
     assert seg_after.vehicle_id == v1.id
-    assert seg_after.start_at.date() == datetime(2024,1,2).date()
+    assert seg_after.start_at == datetime(2024,1,3)
     assert seg_after.end_at == datetime(2024,1,3,16)
     assert Reservation.query.get(r.id).vehicle_id is None


### PR DESCRIPTION
## Summary
- Trim before and after reservation segments by one microsecond so they don't cover the selected day
- Align segment-day tests with the new boundaries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b98b7f45cc833094d6ac63e967503c