### PR TITLE
Remove reservation split option

### DIFF
--- a/app.py
+++ b/app.py
@@ -678,33 +678,6 @@ def manage_request(rid):
                 db.session.commit()
                 flash("Segment ajouté.", "success")
                 return redirect(url_for("admin_reservations"))
-        elif action == "split":
-            split_at = datetime.fromisoformat(request.form.get("split_at"))
-            veh1 = int(request.form.get("vehicle_id1"))
-            veh2 = int(request.form.get("vehicle_id2"))
-            conflict1 = has_conflict(veh1, r.start_at, split_at, exclude_reservation_id=r.id)
-            conflict2 = has_conflict(veh2, split_at, r.end_at, exclude_reservation_id=r.id)
-            if conflict1 or conflict2:
-                flash("Conflit détecté lors de la création du segment.", "danger")
-            else:
-                seg1 = ReservationSegment(
-                    reservation_id=r.id,
-                    vehicle_id=veh1,
-                    start_at=r.start_at,
-                    end_at=split_at,
-                )
-                seg2 = ReservationSegment(
-                    reservation_id=r.id,
-                    vehicle_id=veh2,
-                    start_at=split_at,
-                    end_at=r.end_at,
-                )
-                r.vehicle_id = None
-                r.status = "approved"
-                db.session.add_all([seg1, seg2])
-                db.session.commit()
-                flash("Segments créés et véhicules attribués.", "success")
-                return redirect(url_for("admin_reservations"))
         elif action == "reject":
             r.status = "rejected"
             db.session.commit()

--- a/templates/manage_request.html
+++ b/templates/manage_request.html
@@ -60,31 +60,4 @@
 </form>
 {% endif %}
 
-<hr/>
-<h2 class="h6">Diviser la réservation</h2>
-<form method="post" class="row g-2">
-  <div class="col-md-4">
-    <label class="form-label">Véhicule segment 1</label>
-    <select name="vehicle_id1" class="form-select" required>
-      {% for v, _ in availability %}
-        <option value="{{ v.id }}">{{ v.code }}</option>
-      {% endfor %}
-    </select>
-  </div>
-  <div class="col-md-4">
-    <label class="form-label">Heure de coupure</label>
-    <input type="datetime-local" name="split_at" class="form-control" required>
-  </div>
-  <div class="col-md-4">
-    <label class="form-label">Véhicule segment 2</label>
-    <select name="vehicle_id2" class="form-select" required>
-      {% for v, _ in availability %}
-        <option value="{{ v.id }}">{{ v.code }}</option>
-      {% endfor %}
-    </select>
-  </div>
-  <div class="col-12">
-    <button name="action" value="split" class="btn btn-primary mt-2">Créer les segments</button>
-  </div>
-</form>
 {% endblock %}


### PR DESCRIPTION
## Summary
- drop split branch from manage_request route
- delete split reservation form
- remove split-related tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b992d23d088330a9b9e1bf2f43bdb2