### PR TITLE
Allow admins to manage reservation segments

### DIFF
--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -42,7 +42,11 @@
           {% endfor %}
           {% for s in segments if s.vehicle_id==v.id and s.start_at.date() <= day.date() <= s.end_at.date() %}
             {% set cell_has_res = true %}
-            <span class="badge bg-primary">{{ s.reservation.user.name }} ({{ slot_label(s, day) }})</span>
+            {% if user and user.role in ['admin', 'superadmin'] %}
+              <a href="{{ url_for('manage_segment', sid=s.id) }}" class="badge bg-primary">{{ s.reservation.user.name }} ({{ slot_label(s, day) }})</a>
+            {% else %}
+              <span class="badge bg-primary">{{ s.reservation.user.name }} ({{ slot_label(s, day) }})</span>
+            {% endif %}
           {% endfor %}
           {% if not cell_has_res and user and user.role in ['admin', 'superadmin'] %}
             <a href="{{ url_for('new_request') }}" class="d-block w-100 h-100 text-decoration-none">&nbsp;</a>

--- a/templates/manage_segment.html
+++ b/templates/manage_segment.html
@@ -1,0 +1,37 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 class="h4">Gérer le segment #{{ seg.id }}</h1>
+
+<div class="card mb-3">
+  <div class="card-body">
+    <p><strong>Réservation :</strong> #{{ seg.reservation.id }} — {{ seg.reservation.user.name }}</p>
+    <p><strong>Période :</strong> {{ seg.start_at.strftime('%d/%m/%Y %H:%M') }} → {{ seg.end_at.strftime('%d/%m/%Y %H:%M') }}</p>
+  </div>
+</div>
+
+<h2 class="h6">Disponibilité des véhicules</h2>
+<form method="post">
+  <table class="table table-bordered align-middle">
+    <thead>
+      <tr><th>Véhicule</th><th>Disponible</th><th>Sélection</th></tr>
+    </thead>
+    <tbody>
+    {% for v, free in availability %}
+      <tr>
+        <td><strong>{{ v.code }}</strong>{% if v.label %} — {{ v.label }}{% endif %}</td>
+        <td>{% if free %}✅ Libre{% else %}❌ Occupé{% endif %}</td>
+        <td>
+          <input type="radio" name="vehicle_id" value="{{ v.id }}"
+                 {% if not free %}disabled{% endif %}
+                 {% if v.id == seg.vehicle_id %}checked{% endif %}>
+        </td>
+      </tr>
+    {% else %}
+      <tr><td colspan="3" class="text-center">Aucun véhicule.</td></tr>
+    {% endfor %}
+    </tbody>
+  </table>
+  <button name="action" value="update" class="btn btn-primary">Enregistrer</button>
+  <button name="action" value="delete" class="btn btn-outline-danger">Supprimer le segment</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add `/admin/manage/segment/<sid>` route to update or delete reservation segments
- Link calendar segments to the new management route
- Simplify day segmentation logic to avoid locking remaining days
- Provide a segment management interface
- Test repeated segmentation and segment modification

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9977e8d888330ad301ed32a9bab37