### PR TITLE
Handle partially segmented reservations in month view

### DIFF
--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -33,11 +33,17 @@
         <td class="text-center" style="min-width:40px;">
           {% set cell_has_res = false %}
           {% for r in reservations if r.vehicle_id==v.id and r.start_at.date() <= day.date() <= r.end_at.date() %}
-            {% set cell_has_res = true %}
-            {% if user and user.role in ['admin', 'superadmin'] %}
-              <a href="{{ url_for('manage_request', rid=r.id, day=day.strftime('%Y-%m-%d')) }}" class="badge bg-success">{{ r.user.name }} ({{ slot_label(r, day) }})</a>
-            {% else %}
-              <span class="badge bg-success">{{ r.user.name }} ({{ slot_label(r, day) }})</span>
+            {% set ns = namespace(has_seg=false) %}
+            {% for s in segments if s.reservation_id==r.id and s.start_at.date() <= day.date() <= s.end_at.date() %}
+              {% set ns.has_seg = true %}
+            {% endfor %}
+            {% if not ns.has_seg %}
+              {% set cell_has_res = true %}
+              {% if user and user.role in ['admin', 'superadmin'] %}
+                <a href="{{ url_for('manage_request', rid=r.id, day=day.strftime('%Y-%m-%d')) }}" class="badge bg-success">{{ r.user.name }} ({{ slot_label(r, day) }})</a>
+              {% else %}
+                <span class="badge bg-success">{{ r.user.name }} ({{ slot_label(r, day) }})</span>
+              {% endif %}
             {% endif %}
           {% endfor %}
           {% for s in segments if s.vehicle_id==v.id and s.start_at.date() <= day.date() <= s.end_at.date() %}


### PR DESCRIPTION
## Summary
- Skip rendering of reservations on days covered by segments so only remaining days show in calendar view
- Add regression test ensuring partially segmented reservations display correctly

## Testing
- `pytest tests/test_segments.py::test_calendar_month_partially_segmented_shows_remaining_days -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b9a46fcf788330bef9f050928af7c8