### PR TITLE
Add responsive wrapper for calendar month table

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -1,2 +1,4 @@
 
 .bg-success-subtle{background:#d1e7dd}
+
+body { overflow-x: hidden; }

--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -15,6 +15,7 @@
   <a href="{{ url_for('calendar_month', y=next_y, m=next_m) }}">&rarr;</a>
 </p>
 {% set days = (end - start).days %}
+<div class="table-responsive">
 <table class="table table-bordered table-sm align-middle">
   <thead>
     <tr>
@@ -63,6 +64,7 @@
     {% endfor %}
   </tbody>
 </table>
+</div>
 <p class="text-muted">Légende : <span class="badge bg-success">Nom du réservant (Matin/Après-midi/Journée)</span> = Réservé (approuvé)</p>
 {% if user and user.role in ['admin', 'superadmin'] %}
   <a class="btn btn-outline-secondary" href="{{ url_for('export_pdf_month') }}">Exporter PDF du mois</a>


### PR DESCRIPTION
## Summary
- wrap monthly calendar table in a Bootstrap `table-responsive` container
- hide global horizontal scrollbar via CSS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9a9e169808330a72290b2039a888b