### PR TITLE
Add search filter to admin user list

### DIFF
--- a/app.py
+++ b/app.py
@@ -336,7 +336,11 @@ def contact():
 @role_required("admin", "superadmin")
 def admin_users():
     u = current_user()
-    users = User.query.order_by(User.name).all()
+    q = request.args.get("q")
+    users_query = User.query
+    if q:
+        users_query = users_query.filter(User.name.ilike(f"%{q}%"))
+    users = users_query.order_by(User.name).all()
     return render_template(
         "admin_users.html",
         users=users,

--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,5 +1,9 @@
 {% extends "base.html" %}{% block title %}Administration – Utilisateurs{% endblock %}{% block content %}
 <h4 class="mb-3">Utilisateurs</h4>
+<form method="get" action="{{ url_for('admin_users') }}" class="mb-3">
+  <input type="text" name="q" value="{{ request.args.get('q','') }}" />
+  <button type="submit">Chercher</button>
+</form>
 <table class="table table-striped align-middle">
   <thead><tr><th>ID</th><th>Prénom</th><th>Nom</th><th>Email</th><th>Rôle</th><th>Status</th><th>Actions</th></tr></thead>
   <tbody>


### PR DESCRIPTION
## Summary
- allow filtering users by name via `q` query parameter in admin listing
- add search form in admin users template with query persistence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9bdba69608330a675483cfe792cdd