### PR TITLE
Renommer Vue mensuelle en Planning mensuel

### DIFF
--- a/templates/admin_home.html
+++ b/templates/admin_home.html
@@ -4,7 +4,7 @@
 <div class="list-group">
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_reservations') }}">Gestion des réservations</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_vehicles') }}">Gestion du parc</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Vue mensuelle</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Planning mensuel</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Nouvelle demande</a>
 </div>
 {% endblock %}

--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -8,7 +8,7 @@
 {% set next_y = end.year %}
 {% set next_m = end.month %}
 
-<h1 class="h4">Vue mensuelle (lecture seule)</h1>
+<h1 class="h4">Planning mensuel (lecture seule)</h1>
 <p>
   <a href="{{ url_for('calendar_month', y=prev_y, m=prev_m) }}">&larr;</a>
   Mois: {{ start.strftime('%B %Y') }}

--- a/templates/superadmin_home.html
+++ b/templates/superadmin_home.html
@@ -6,7 +6,7 @@
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_reservations') }}">Gestion des réservations</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_leaves') }}">Gestion des congés</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_vehicles') }}">Gestion du parc</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Vue mensuelle</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Planning mensuel</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Nouvelle demande</a>
 </div>
 {% endblock %}

--- a/templates/user_home.html
+++ b/templates/user_home.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h1 class="h4">Accueil utilisateur</h1>
 <div class="list-group">
-  <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Vue mensuelle</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Planning mensuel</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Nouvelle demande</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('contact') }}">Contact</a>
 </div>

--- a/tests/test_navigation_links.py
+++ b/tests/test_navigation_links.py
@@ -26,7 +26,7 @@ def _render_nav(role: str) -> str:
 def test_links_hidden_for_superadmin(role):
     html = _render_nav(role)
     assert 'Accueil' in html
-    assert 'Vue mensuelle' not in html
+    assert 'Planning mensuel' not in html
     assert 'Nouvelle demande' not in html
 
 
@@ -51,10 +51,10 @@ def _render_home(role: str) -> str:
 @pytest.mark.parametrize(
     'role,links',
     [
-        (User.ROLE_USER, ['Vue mensuelle', 'Nouvelle demande', 'Contact']),
+        (User.ROLE_USER, ['Planning mensuel', 'Nouvelle demande', 'Contact']),
         (
             User.ROLE_ADMIN,
-            ['Gestion du parc', 'Gestion des réservations', 'Vue mensuelle', 'Nouvelle demande'],
+            ['Gestion du parc', 'Gestion des réservations', 'Planning mensuel', 'Nouvelle demande'],
         ),
         (
             User.ROLE_SUPERADMIN,
@@ -63,7 +63,7 @@ def _render_home(role: str) -> str:
                 'Gestion du parc',
                 'Gestion des réservations',
                 'Gestion des congés',
-                'Vue mensuelle',
+                'Planning mensuel',
                 'Nouvelle demande',
             ],
         ),


### PR DESCRIPTION
## Summary
- Harmonise les intitulés des vues mensuelles en "Planning mensuel" pour les différentes pages utilisateur et administrateur
- Met à jour les tests de navigation pour refléter ce changement

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9cac60d5c83309e51d0ff8782745b