### PR TITLE
Renomme 'Nouvelle demande' en 'Demande de réservation'

### DIFF
--- a/app.py
+++ b/app.py
@@ -283,7 +283,7 @@ def new_request():
             recipients = list(set(recipients))
             try:
                 send_mail_msmtp(
-                    "Nouvelle demande de réservation",
+                    "Demande de réservation",
                     f"Une nouvelle demande a été soumise par {current_user().name}.",
                     recipients,
                 )

--- a/templates/admin_home.html
+++ b/templates/admin_home.html
@@ -5,6 +5,6 @@
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_reservations') }}">Gestion des réservations</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_vehicles') }}">Gestion du parc</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Planning mensuel</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Nouvelle demande</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Demande de réservation</a>
 </div>
 {% endblock %}

--- a/templates/new_request.html
+++ b/templates/new_request.html
@@ -1,7 +1,7 @@
 
 {% extends "base.html" %}
 {% block content %}
-<h1 class="h4">Nouvelle demande</h1>
+<h1 class="h4">Demande de réservation</h1>
 <form method="post">
   {{ form.hidden_tag() }}
   <div class="row">

--- a/templates/superadmin_home.html
+++ b/templates/superadmin_home.html
@@ -7,6 +7,6 @@
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_leaves') }}">Gestion des congés</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('admin_vehicles') }}">Gestion du parc</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Planning mensuel</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Nouvelle demande</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Demande de réservation</a>
 </div>
 {% endblock %}

--- a/templates/user_home.html
+++ b/templates/user_home.html
@@ -3,7 +3,7 @@
 <h1 class="h4">Accueil utilisateur</h1>
 <div class="list-group">
   <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Planning mensuel</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Nouvelle demande</a>
+  <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Demande de réservation</a>
   <a class="list-group-item list-group-item-action" href="{{ url_for('contact') }}">Contact</a>
 </div>
 {% endblock %}

--- a/tests/test_navigation_links.py
+++ b/tests/test_navigation_links.py
@@ -27,7 +27,7 @@ def test_links_hidden_for_superadmin(role):
     html = _render_nav(role)
     assert 'Accueil' in html
     assert 'Planning mensuel' not in html
-    assert 'Nouvelle demande' not in html
+    assert 'Demande de réservation' not in html
 
 
 def _render_home(role: str) -> str:
@@ -51,10 +51,10 @@ def _render_home(role: str) -> str:
 @pytest.mark.parametrize(
     'role,links',
     [
-        (User.ROLE_USER, ['Planning mensuel', 'Nouvelle demande', 'Contact']),
+        (User.ROLE_USER, ['Planning mensuel', 'Demande de réservation', 'Contact']),
         (
             User.ROLE_ADMIN,
-            ['Gestion du parc', 'Gestion des réservations', 'Planning mensuel', 'Nouvelle demande'],
+            ['Gestion du parc', 'Gestion des réservations', 'Planning mensuel', 'Demande de réservation'],
         ),
         (
             User.ROLE_SUPERADMIN,
@@ -64,7 +64,7 @@ def _render_home(role: str) -> str:
                 'Gestion des réservations',
                 'Gestion des congés',
                 'Planning mensuel',
-                'Nouvelle demande',
+                'Demande de réservation',
             ],
         ),
     ],


### PR DESCRIPTION
## Summary
- Renomme les liens "Nouvelle demande" en "Demande de réservation" pour les pages d'accueil
- Adapte l'objet du courriel et l'en-tête du formulaire de demande
- Met à jour les tests de navigation avec la nouvelle terminologie

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9cb91ccdc8330b10fe486bb4abd0c