### PR TITLE
Purge expired reservation requests via CLI and cron

### DIFF
--- a/tests/test_reservation_purge.py
+++ b/tests/test_reservation_purge.py
@@ -1,0 +1,47 @@
+import pytest
+from datetime import datetime, timedelta
+from app import app, purge_expired_requests
+from models import db, User, Reservation
+
+
+def test_purge_expired_pending_reservations():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+
+        user = User(
+            name='User',
+            first_name='Foo',
+            last_name='Bar',
+            email='u@example.com',
+            role=User.ROLE_USER,
+            password_hash='x'
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        old_end = datetime.utcnow() - timedelta(days=3)
+        new_end = datetime.utcnow() - timedelta(days=1)
+        old_res = Reservation(
+            user_id=user.id,
+            start_at=old_end - timedelta(hours=1),
+            end_at=old_end,
+            status='pending'
+        )
+        fresh_res = Reservation(
+            user_id=user.id,
+            start_at=new_end - timedelta(hours=1),
+            end_at=new_end,
+            status='pending'
+        )
+        db.session.add_all([old_res, fresh_res])
+        db.session.commit()
+
+        purge_expired_requests()
+
+        assert Reservation.query.count() == 1
+        assert Reservation.query.first().id == fresh_res.id
+        db.drop_all()

--- a/tools/fin_de_journee.sh
+++ b/tools/fin_de_journee.sh
@@ -10,6 +10,9 @@ TS="$(date +%Y%m%d_%H%M%S)"
 echo "== Fin de journée - $DATE =="
 echo "Répertoire: $REPO"
 
+# Purge quotidienne des demandes de réservation expirées
+flask --app app purge-expired-requests >/dev/null 2>&1 || true
+
 # 1) Patch des changements non commités (inclut l'intention d'ajout des nouveaux fichiers)
 #    -N : enregistre l’intention d’ajouter les nouveaux fichiers sans les indexer totalement
 git add -N . >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- add `purge_expired_requests` to remove pending reservations older than two days
- expose purge as `flask purge-expired-requests` CLI command
- run purge daily from `tools/fin_de_journee.sh`
- test that expired pending reservations are purged

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c14c4e22708330a9bb03b8339eb366