### PR TITLE
Add title blocks to templates

### DIFF
--- a/templates/403.html
+++ b/templates/403.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Accès interdit – Véhicules{% endblock %}
 {% block content %}
   <h1>Accès interdit</h1>
   <p>Vous n'avez pas les droits nécessaires pour accéder à cette page.</p>

--- a/templates/admin_home.html
+++ b/templates/admin_home.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Administration – Accueil{% endblock %}
 {% block content %}
 <h1 class="h4">Accueil administration</h1>
 <div class="list-group">

--- a/templates/admin_leaves.html
+++ b/templates/admin_leaves.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Administration – Notifications{% endblock %}
 {% block content %}
 <h1 class="h4">Notifications de demandes</h1>
 <form method="post">

--- a/templates/admin_reservations.html
+++ b/templates/admin_reservations.html
@@ -1,5 +1,6 @@
 
 {% extends "base.html" %}
+{% block title %}Administration – Réservations{% endblock %}
 {% block content %}
 <h1 class="h4">Réservations (admin)</h1>
 <table class="table table-striped">

--- a/templates/admin_vehicles.html
+++ b/templates/admin_vehicles.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Administration – Véhicules{% endblock %}
 {% block content %}
 <div class="container">
   <h2>Véhicules CSP</h2>

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Vehicules{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="{{ url_for('static', filename='styles.css') }}" rel="stylesheet">
 <style> .user-name{max-width:12rem} @media (max-width:576px){ .user-name{max-width:8rem} } </style>

--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -1,5 +1,6 @@
 
 {% extends "base.html" %}
+{% block title %}Planning mensuel – Véhicules{% endblock %}
 {% block content %}
 {# Calcul mois précédent et suivant #}
 {% set prev = start - timedelta(days=1) %}

--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Contact – Véhicules{% endblock %}
 {% block content %}
 <h1 class="h4">Contact</h1>
 <form method="post">

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,5 +1,6 @@
 
 {% extends "base.html" %}
+{% block title %}Connexion – Véhicules{% endblock %}
 {% block content %}
 <h1 class="h4">Connexion</h1>
 <form method="post">

--- a/templates/login_basic.html
+++ b/templates/login_basic.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Connexion – Véhicules{% endblock %}
 {% block content %}
 <h1 class="h4">Connexion</h1>
 <form method="post" action="{{ url_for('login') }}">

--- a/templates/manage_request.html
+++ b/templates/manage_request.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Gérer la demande – Véhicules{% endblock %}
 {% block content %}
 <h1 class="h4">Gérer la demande #{{ r.id }}</h1>
 

--- a/templates/manage_segment.html
+++ b/templates/manage_segment.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Gérer le segment – Véhicules{% endblock %}
 {% block content %}
 <h1 class="h4">Gérer le segment #{{ seg.id }}</h1>
 

--- a/templates/new_request.html
+++ b/templates/new_request.html
@@ -1,5 +1,6 @@
 
 {% extends "base.html" %}
+{% block title %}Demande de réservation – Véhicules{% endblock %}
 {% block content %}
 <h1 class="h4">Demande de réservation</h1>
 <form method="post">

--- a/templates/superadmin_home.html
+++ b/templates/superadmin_home.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Superadmin – Accueil{% endblock %}
 {% block content %}
 <h1 class="h4">Accueil administration</h1>
 <div class="list-group">

--- a/templates/user_form.html
+++ b/templates/user_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Administration – Modifier utilisateur{% endblock %}
 {% block content %}
 <h2>Modifier utilisateur #{{ target.id }}</h2>
 <form method="post">

--- a/templates/user_home.html
+++ b/templates/user_home.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Accueil utilisateur – Véhicules{% endblock %}
 {% block content %}
 <h1 class="h4">Accueil utilisateur</h1>
 <div class="list-group">

--- a/templates/vehicle_form.html
+++ b/templates/vehicle_form.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% block title %}Administration – Véhicule{% endblock %}
 {% block content %}
 <h2>{{ "Nouveau véhicule" if not vehicle else "Modifier véhicule #" ~ vehicle.id }}</h2>
 <form method="post">


### PR DESCRIPTION
## Summary
- Add default `{% block title %}` in base template head
- Provide page titles for all templates extending `base.html`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1517a2e708330ad6bc5ce38944855