### PR TITLE
Improve search form styling on admin users page

### DIFF
--- a/templates/admin_users.html
+++ b/templates/admin_users.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}{% block title %}Administration – Utilisateurs{% endblock %}{% block content %}
 <h4 class="mb-3">Utilisateurs</h4>
 <form method="get" action="{{ url_for('admin_users') }}" class="mb-3">
-  <input type="text" name="q" value="{{ request.args.get('q','') }}" />
-  <button type="submit">Chercher</button>
+  <input type="text" name="q" value="{{ request.args.get('q','') }}" class="form-control" />
+  <button type="submit" class="btn btn-primary">Chercher</button>
 </form>
 <p class="text-muted small mb-2">Les lignes en surbrillance correspondent aux utilisateurs en attente d'activation.</p>
 <div class="table-responsive">


### PR DESCRIPTION
## Summary
- style: apply Bootstrap form-control to admin user search input
- style: add primary button styling to search submit

## Testing
- `python - <<'PY' ...` (desktop/mobile request)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1554b25a08330a3ce764527ada325