### PR TITLE
Remove duplicate registration link from login template

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -1,4 +1,3 @@
-
 {% extends "base.html" %}
 {% block title %}Connexion – Véhicules{% endblock %}
 {% block content %}
@@ -14,10 +13,5 @@
   <a style="display:block;font-weight:600" href="{{ url_for('register') }}">Première connexion ? Créer un compte</a>
 </div>
 {% endblock %}
-
-<hr class="my-3">
-<div class="text-center">
-  <a href="{{ url_for('register') }}">Première connexion ? Créer un compte</a>
-</div>
 <!-- MARK: LOGIN-TPL -->
 <!-- MARK:LOGIN-HTML -->


### PR DESCRIPTION
## Summary
- remove duplicate registration link from login page to leave single sign-up link

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c15611447c8330bde4b5311a855446