### PR TITLE
Add basic PWA manifest and service worker

### DIFF
--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Vehicules",
+  "short_name": "Vehicules",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#0d6efd"
+}

--- a/static/service-worker.js
+++ b/static/service-worker.js
@@ -1,0 +1,17 @@
+const CACHE_NAME = 'vehicules-cache-v1';
+const URLS_TO_CACHE = [
+  '/',
+  '/static/styles.css'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(URLS_TO_CACHE))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,7 @@
   <title>{% block title %}Vehicules{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="{{ url_for('static', filename='styles.css') }}" rel="stylesheet">
+  <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 <style> .user-name{max-width:12rem} @media (max-width:576px){ .user-name{max-width:8rem} } </style>
 </head>
 <body>
@@ -43,5 +44,10 @@
   {% block content %}{% endblock %}
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register("{{ url_for('static', filename='service-worker.js') }}");
+}
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- define app metadata via web manifest
- add service worker for offline caching
- link manifest and register service worker in base template

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c15bff61948330a4cbe50179fbc011