### PR TITLE
Refactor templates to use CSS classes over inline styles

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -1,5 +1,24 @@
 .bg-success-subtle{background:#d1e7dd}
 
+.legend-text {
+  font-size: 10px;
+  color: #666;
+}
+
+.sticky-col {
+  position: sticky;
+  left: 0;
+  background: #fff;
+}
+
+.min-w-40 {
+  min-width: 40px;
+}
+
+.max-w-520 {
+  max-width: 520px;
+}
+
 @media (max-width: 768px) {
   body {
     font-size: 0.9rem;

--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -20,7 +20,7 @@
 <table class="table table-bordered table-sm align-middle">
   <thead>
     <tr>
-      <th style="position: sticky; left:0; background:#fff;">Véhicule</th>
+      <th class="sticky-col">Véhicule</th>
       {% for i in range(days) %}
         <th class="text-center">{{ (start + timedelta(days=(i|int))).strftime("%d") }}</th>
       {% endfor %}
@@ -29,10 +29,10 @@
   <tbody>
     {% for v in vehicles %}
     <tr>
-      <td style="position: sticky; left:0; background:#fff;"><strong>{{ v.code }}</strong></td>
+      <td class="sticky-col"><strong>{{ v.code }}</strong></td>
       {% for i in range(days) %}
     {% set day = start + timedelta(days=(i|int)) %}
-        <td class="text-center" style="min-width:40px;">
+        <td class="text-center min-w-40">
           {% set cell_has_res = false %}
           {% for r in reservations if r.vehicle_id==v.id and r.start_at.date() <= day.date() <= r.end_at.date() %}
             {% set ns = namespace(has_seg=false) %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -10,7 +10,7 @@
 </form>
 <hr class="my-3">
 <div class="text-center">
-  <a style="display:block;font-weight:600" href="{{ url_for('register') }}">Première connexion ? Créer un compte</a>
+  <a class="d-block fw-semibold" href="{{ url_for('register') }}">Première connexion ? Créer un compte</a>
 </div>
 {% endblock %}
 <!-- MARK: LOGIN-TPL -->

--- a/templates/new_request.html
+++ b/templates/new_request.html
@@ -20,7 +20,7 @@
     </label>
   </div>
   <div class="form-text mb-3">La date de fin est uniquement nécessaire pour les réservations de plusieurs jours.</div>
-  <div id="end_fields" class="row" style="display: none;">
+  <div id="end_fields" class="row d-none">
     <div class="col-md-6 mb-3">{{ form.end_date.label }} {{ form.end_date(class="form-control") }}</div>
     <div class="col-md-6 mb-3">{{ form.end_slot.label }} {{ form.end_slot(class="form-select") }}</div>
   </div>
@@ -37,7 +37,7 @@
   const endSlotSelect = document.getElementById('end_slot');
   function toggleEndFields() {
     const enabled = multiDay.checked;
-    endFields.style.display = enabled ? 'flex' : 'none';
+    endFields.classList.toggle('d-none', !enabled);
     endDateInput.disabled = endSlotSelect.disabled = !enabled;
     if (!enabled) {
       endDateInput.value = '';

--- a/templates/pdf_month.html
+++ b/templates/pdf_month.html
@@ -1,5 +1,6 @@
 
 <!doctype html><html><head><meta charset="utf-8">
+<link href="{{ url_for('static', filename='custom.css') }}" rel="stylesheet">
 <style>
 body{font-family:sans-serif;font-size:11px}
 table{width:100%;border-collapse:collapse}th,td{border:1px solid #999;padding:3px;vertical-align:top;text-align:center}
@@ -31,5 +32,5 @@ th.sticky, td.sticky{position:sticky;left:0;background:#fff}
 </tbody>
 </table>
 </div>
-<p style="font-size:10px;color:#666;">Légende: Matin / Après-midi / Journée = Réservé (approuvé)</p>
+<p class="legend-text">Légende: Matin / Après-midi / Journée = Réservé (approuvé)</p>
 </body></html>

--- a/templates/register.html
+++ b/templates/register.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}{% block title %}Inscription – Véhicules{% endblock %}{% block content %}
-<div class="card mx-auto" style="max-width:520px"><div class="card-body">
+<div class="card mx-auto max-w-520"><div class="card-body">
 <h5 class="card-title mb-3">Créer un compte</h5>
 <form method="post">
   {{ form.hidden_tag() }}


### PR DESCRIPTION
## Summary
- Remove inline styles from templates and apply Bootstrap utility classes
- Introduce custom CSS helpers for sticky columns, element sizing and legend text
- Link shared styles to PDF template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1687ceb1483308791c65286211bec