### PR TITLE
Refactor plain login template to use Bootstrap

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -19,6 +19,10 @@
   max-width: 520px;
 }
 
+.max-w-420 {
+  max-width: 420px;
+}
+
 @media (max-width: 768px) {
   body {
     font-size: 0.9rem;

--- a/templates/login_plain.html
+++ b/templates/login_plain.html
@@ -1,55 +1,31 @@
-<!doctype html>
-<html lang="fr">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Connexion</title>
-  <style>
-    html,body{height:100%}
-    body{
-      margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,sans-serif;
-      background:#f6f7fb; color:#111;
-      display:flex; align-items:center; justify-content:center; min-height:100vh;
-    }
-    .card{width:100%;max-width:420px;background:#fff;border-radius:14px;
-          box-shadow:0 8px 30px rgba(0,0,0,.08);padding:24px;}
-    h1{margin:0 0 8px;font-size:22px;font-weight:700;text-align:center}
-    p.sub{margin:0 0 18px;color:#666;font-size:14px;text-align:center}
-    form{max-width:320px;margin:0 auto}
-    label{display:block;font-size:14px;margin:10px 0 6px}
-    input[type="email"],input[type="password"]{
-      width:100%;padding:10px 12px;border:1px solid #dcdfe4;border-radius:10px;
-      font-size:15px;outline:none;box-sizing:border-box
-    }
-    input:focus{border-color:#7aa7ff;box-shadow:0 0 0 3px rgba(64,128,255,.15)}
-    .actions{margin-top:16px;display:flex;gap:10px;align-items:center;justify-content:space-between;flex-wrap:wrap}
-    .btn{appearance:none;border:0;background:#0d6efd;color:#fff;border-radius:10px;padding:10px 14px;font-weight:600;cursor:pointer;width:100%}
-    .link{font-size:14px;color:#0d6efd;text-decoration:none;display:inline-block;margin-top:10px}
-    .flash{margin:0 0 12px;padding:10px 12px;border-radius:10px;background:#fff3cd;color:#664d03;border:1px solid #ffe69c;font-size:14px}
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h1>Connexion</h1>
-    <p class="sub">Accédez à votre espace de réservation.</p>
-
-    {% with messages = get_flashed_messages(with_categories=true) %}
-      {% if messages %}<ul class="flash">{% for c,m in messages %}<li>{{m}}</li>{% endfor %}</ul>{% endif %}
-    {% endwith %}
+{% extends "base.html" %}
+{% block title %}Connexion – Véhicules{% endblock %}
+{% block content %}
+<div class="card mx-auto max-w-420 mt-5">
+  <div class="card-body">
+    <h1 class="h4 text-center mb-1">Connexion</h1>
+    <p class="text-center text-muted mb-3">Accédez à votre espace de réservation.</p>
 
     <form method="post" action="{{ url_for('login', **request.args) }}">
       {{ form.csrf_token }}
-      <label>Email
-        {{ form.email(type="email", required=True) }}
-      </label>
-      <label>Mot de passe
-        {{ form.password(type="password", required=True) }}
-      </label>
-      <button class="btn" type="submit">Se connecter</button>
+      <div class="mb-3">
+        <label class="form-label">Email</label>
+        {{ form.email(class="form-control", type="email", required=True) }}
+      </div>
+      <div class="mb-3">
+        <label class="form-label">Mot de passe</label>
+        {{ form.password(class="form-control", type="password", required=True) }}
+      </div>
+      <div class="d-grid mb-3">
+        <button class="btn btn-primary" type="submit">Se connecter</button>
+      </div>
     </form>
 
-    <a class="link" href="{{ url_for('register') }}">Créer un compte</a>
-    <a class="link" href="/first_login">Première connexion</a>
+    <div class="text-center">
+      <a class="btn btn-link d-block" href="{{ url_for('register') }}">Créer un compte</a>
+      <a class="btn btn-link d-block" href="/first_login">Première connexion</a>
+    </div>
   </div>
-</body>
-</html>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
## Summary
- Rework `login_plain.html` to inherit `base.html` and Bootstrap classes
- Remove inline styles and add `.max-w-420` utility in `custom.css`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c169ab45a0833091de6892759084a4