### PR TITLE
chore: apply bootswatch classes

### DIFF
--- a/templates/contact.html
+++ b/templates/contact.html
@@ -1,10 +1,14 @@
 {% extends "base.html" %}
 {% block title %}Contact – Véhicules{% endblock %}
 {% block content %}
-<h1 class="h4">Contact</h1>
-<form method="post">
-  {{ form.hidden_tag() }}
-  <div class="mb-3">{{ form.message.label }} {{ form.message(class="form-control", rows=3) }}</div>
-  {{ form.submit(class="btn btn-success") }}
-</form>
+<div class="card">
+  <div class="card-body">
+    <h1 class="h4">Contact</h1>
+    <form method="post">
+      {{ form.hidden_tag() }}
+      <div class="mb-3">{{ form.message.label(class="form-label") }} {{ form.message(class="form-control", rows=3) }}</div>
+      {{ form.submit(class="btn btn-success") }}
+    </form>
+  </div>
+</div>
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,16 +1,20 @@
 {% extends "base.html" %}
 {% block title %}Connexion – Véhicules{% endblock %}
 {% block content %}
-<h1 class="h4">Connexion</h1>
-<form method="post">
-  {{ form.hidden_tag() }}
-  <div class="mb-3">{{ form.email.label }} {{ form.email(class="form-control") }}</div>
-  <div class="mb-3">{{ form.password.label }} {{ form.password(class="form-control") }}</div>
-  {{ form.submit(class="btn btn-primary") }}
-</form>
-<hr class="my-3">
-<div class="text-center">
-  <a class="d-block fw-semibold" href="{{ url_for('register') }}">Première connexion ? Créer un compte</a>
+<div class="card mx-auto max-w-420">
+  <div class="card-body">
+    <h5 class="card-title mb-3">Connexion</h5>
+    <form method="post">
+      {{ form.hidden_tag() }}
+      <div class="mb-3">{{ form.email.label(class="form-label") }} {{ form.email(class="form-control") }}</div>
+      <div class="mb-3">{{ form.password.label(class="form-label") }} {{ form.password(class="form-control") }}</div>
+      {{ form.submit(class="btn btn-primary w-100") }}
+    </form>
+    <hr class="my-3">
+    <div class="text-center">
+      <a class="d-block fw-semibold" href="{{ url_for('register') }}">Première connexion ? Créer un compte</a>
+    </div>
+  </div>
 </div>
 {% endblock %}
 <!-- MARK: LOGIN-TPL -->

--- a/templates/new_request.html
+++ b/templates/new_request.html
@@ -2,34 +2,38 @@
 {% extends "base.html" %}
 {% block title %}Demande de réservation – Véhicules{% endblock %}
 {% block content %}
-<h1 class="h4">Demande de réservation</h1>
-<form method="post">
-  {{ form.hidden_tag() }}
-  <div class="row">
-    <div class="col-md-6 mb-3">{{ form.first_name.label }} {{ form.first_name(class="form-control") }}</div>
-    <div class="col-md-6 mb-3">{{ form.last_name.label }} {{ form.last_name(class="form-control") }}</div>
+<div class="card">
+  <div class="card-body">
+    <h1 class="h4">Demande de réservation</h1>
+    <form method="post">
+      {{ form.hidden_tag() }}
+      <div class="row">
+        <div class="col-md-6 mb-3">{{ form.first_name.label(class="form-label") }} {{ form.first_name(class="form-control") }}</div>
+        <div class="col-md-6 mb-3">{{ form.last_name.label(class="form-label") }} {{ form.last_name(class="form-control") }}</div>
+      </div>
+      <div class="row">
+        <div class="col-md-6 mb-3">{{ form.start_date.label(class="form-label") }} {{ form.start_date(class="form-control") }}</div>
+        <div class="col-md-6 mb-3">{{ form.start_slot.label(class="form-label") }} {{ form.start_slot(class="form-select") }}</div>
+      </div>
+      <div class="form-check mb-3">
+        <input class="form-check-input" type="checkbox" id="multiDay">
+        <label class="form-check-label" for="multiDay">
+          Réservation sur plusieurs jours
+        </label>
+      </div>
+      <div class="form-text mb-3">La date de fin est uniquement nécessaire pour les réservations de plusieurs jours.</div>
+      <div id="end_fields" class="row d-none">
+        <div class="col-md-6 mb-3">{{ form.end_date.label(class="form-label") }} {{ form.end_date(class="form-control") }}</div>
+        <div class="col-md-6 mb-3">{{ form.end_slot.label(class="form-label") }} {{ form.end_slot(class="form-select") }}</div>
+      </div>
+      <div class="mb-3">{{ form.purpose.label(class="form-label") }} {{ form.purpose(class="form-control") }}</div>
+      <div class="form-check mb-3">{{ form.carpool(class="form-check-input") }} {{ form.carpool.label(class="form-check-label") }}</div>
+      <div class="mb-3">{{ form.carpool_with.label(class="form-label") }} {{ form.carpool_with(class="form-control") }}</div>
+      <div class="mb-3">{{ form.notes.label(class="form-label") }} {{ form.notes(class="form-control", rows=3) }}</div>
+      {{ form.submit(class="btn btn-success") }}
+    </form>
   </div>
-  <div class="row">
-    <div class="col-md-6 mb-3">{{ form.start_date.label }} {{ form.start_date(class="form-control") }}</div>
-    <div class="col-md-6 mb-3">{{ form.start_slot.label }} {{ form.start_slot(class="form-select") }}</div>
-  </div>
-  <div class="form-check mb-3">
-    <input class="form-check-input" type="checkbox" id="multiDay">
-    <label class="form-check-label" for="multiDay">
-      Réservation sur plusieurs jours
-    </label>
-  </div>
-  <div class="form-text mb-3">La date de fin est uniquement nécessaire pour les réservations de plusieurs jours.</div>
-  <div id="end_fields" class="row d-none">
-    <div class="col-md-6 mb-3">{{ form.end_date.label }} {{ form.end_date(class="form-control") }}</div>
-    <div class="col-md-6 mb-3">{{ form.end_slot.label }} {{ form.end_slot(class="form-select") }}</div>
-  </div>
-  <div class="mb-3">{{ form.purpose.label }} {{ form.purpose(class="form-control") }}</div>
-  <div class="form-check mb-3">{{ form.carpool(class="form-check-input") }} {{ form.carpool.label(class="form-check-label") }}</div>
-  <div class="mb-3">{{ form.carpool_with.label }} {{ form.carpool_with(class="form-control") }}</div>
-  <div class="mb-3">{{ form.notes.label }} {{ form.notes(class="form-control", rows=3) }}</div>
-  {{ form.submit(class="btn btn-success") }}
-</form>
+</div>
 <script>
   const multiDay = document.getElementById('multiDay');
   const endFields = document.getElementById('end_fields');

--- a/templates/pdf_month.html
+++ b/templates/pdf_month.html
@@ -1,10 +1,10 @@
 
 <!doctype html><html><head><meta charset="utf-8">
+<link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/litera/bootstrap.min.css" rel="stylesheet">
 <link href="{{ url_for('static', filename='custom.css') }}" rel="stylesheet">
 <style>
 body{font-family:sans-serif;font-size:11px}
 table{width:100%;border-collapse:collapse}th,td{border:1px solid #999;padding:3px;vertical-align:top;text-align:center}
-.badge{display:inline-block;background:#d1e7dd;border-radius:3px;padding:2px 4px}
 th.sticky, td.sticky{position:sticky;left:0;background:#fff}
 </style></head><body>
 <h1>Planning véhicules — {{ start.strftime("%B %Y") }}</h1>
@@ -23,7 +23,7 @@ th.sticky, td.sticky{position:sticky;left:0;background:#fff}
 {% set day = start + timedelta(days=i) %}
 <td>
 {% for r in reservations if r.vehicle_id==v.id and r.start_at.date() <= day.date() <= r.end_at.date() %}
-<span class="badge">{{ slot_label(r, day) }}</span>
+<span class="badge text-bg-success">{{ slot_label(r, day) }}</span>
 {% endfor %}
 </td>
 {% endfor %}

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -42,7 +42,8 @@ def test_contact_page_renders():
         resp = client.get('/contact')
         assert resp.status_code == 200
         html = resp.data.decode('utf-8')
-        assert 'Message' in html
+        assert 'class="card"' in html
+        assert 'class="form-label"' in html
         db.drop_all()
 
 

--- a/tests/test_login_page.py
+++ b/tests/test_login_page.py
@@ -1,0 +1,20 @@
+import pytest
+from app import app
+from models import db
+
+
+def test_login_page_bootstrap_classes():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        client = app.test_client()
+        resp = client.get('/login')
+        assert resp.status_code == 200
+        html = resp.data.decode('utf-8')
+        assert 'class="card' in html
+        assert 'class="form-label"' in html
+        db.drop_all()


### PR DESCRIPTION
## Summary
- wrap contact page in Bootstrap card and style form with Bootswatch classes
- convert login and reservation request pages to Bootswatch components
- replace custom PDF badge style with Bootstrap variant
- test contact and login pages for expected UI classes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c16a7a5970833095786daceaef3a07