### PR TITLE
Allow register access without login

### DIFF
--- a/app.py
+++ b/app.py
@@ -121,6 +121,7 @@ def _force_login():
     public = {
         "/login",
         "/first_login",
+        "/register",
         "/logout",
         "/__ping__",
         "/home",

--- a/static/custom.css
+++ b/static/custom.css
@@ -9,6 +9,7 @@
   position: sticky;
   left: 0;
   background: #fff;
+  z-index: 1;
 }
 
 .min-w-40 {


### PR DESCRIPTION
## Summary
- Permit visiting /register without being logged in
- Ensure sticky table columns stay on top with z-index

## Testing
- `pytest`
- `curl -I http://127.0.0.1:8000/login`
- `curl -I http://127.0.0.1:8000/register`


------
https://chatgpt.com/codex/tasks/task_e_68c16bc35ed48330adff5045ed0ba4d6