### PR TITLE
Remove registration links from login pages

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -10,10 +10,6 @@
       <div class="mb-3">{{ form.password.label(class="form-label") }} {{ form.password(class="form-control") }}</div>
       {{ form.submit(class="btn btn-primary w-100") }}
     </form>
-    <hr class="my-3">
-    <div class="text-center">
-      <a class="d-block fw-semibold" href="{{ url_for('register') }}">Première connexion ? Créer un compte</a>
-    </div>
   </div>
 </div>
 {% endblock %}

--- a/templates/login_basic.html
+++ b/templates/login_basic.html
@@ -13,8 +13,4 @@
   </div>
   <button class="btn btn-primary" type="submit">Se connecter</button>
 </form>
-<hr class="my-3">
-<div class="text-center">
-  <a href="{{ url_for('register') }}">Créer un compte</a>
-</div>
 {% endblock %}

--- a/templates/login_plain.html
+++ b/templates/login_plain.html
@@ -20,11 +20,6 @@
         <button class="btn btn-primary" type="submit">Se connecter</button>
       </div>
     </form>
-
-    <div class="text-center">
-      <a class="btn btn-link d-block" href="{{ url_for('register') }}">Créer un compte</a>
-      <a class="btn btn-link d-block" href="/first_login">Première connexion</a>
-    </div>
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- remove register and first-login links from login templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c172b8b1d88330a9b41f64c6b7e31e