### PR TITLE
Clarify registration flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@ Application Flask de gestion des véhicules.
 
 ## Rôles administratifs
 
-Lors de la création d'un compte via `/register`,
-l'application vérifie si l'adresse e‑mail figure dans les variables
-d'environnement `SUPERADMIN_EMAILS` ou `ADMIN_EMAILS`.
+Lors de l'inscription via la page `/register`, l'application vérifie si l'adresse e‑mail figure dans les variables d'environnement `SUPERADMIN_EMAILS` ou `ADMIN_EMAILS` afin d'attribuer automatiquement le rôle approprié.
 
 * `SUPERADMIN_EMAILS` – adresses séparées par des virgules qui recevront le
   rôle `superadmin`.


### PR DESCRIPTION
## Summary
- clarify README instructions to reference only `/register` and simplify admin role setup description

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1748c09288330a7833c1c04f6a1fe