### PR TITLE
Add register link to login forms

### DIFF
--- a/templates/login_basic.html
+++ b/templates/login_basic.html
@@ -13,4 +13,8 @@
   </div>
   <button class="btn btn-primary" type="submit">Se connecter</button>
 </form>
+<hr class="my-3">
+<div class="text-center">
+  <a href="{{ url_for('register') }}">Créer un compte</a>
+</div>
 {% endblock %}

--- a/templates/login_plain.html
+++ b/templates/login_plain.html
@@ -20,6 +20,10 @@
         <button class="btn btn-primary" type="submit">Se connecter</button>
       </div>
     </form>
+    <hr class="my-3">
+    <div class="text-center">
+      <a href="{{ url_for('register') }}">Créer un compte</a>
+    </div>
   </div>
 </div>
 {% endblock %}

--- a/tests/test_login_page.py
+++ b/tests/test_login_page.py
@@ -17,6 +17,6 @@ def test_login_page_bootstrap_classes():
         html = resp.data.decode('utf-8')
         assert 'class="card' in html
         assert 'class="form-label"' in html
-        assert 'Créer un compte' not in html
+        assert 'Créer un compte' in html
         assert 'Première connexion' not in html
         db.drop_all()


### PR DESCRIPTION
## Summary
- add sign-up link to basic and plain login templates
- test presence of registration link on login page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c177a48318833081746f4340478058