### PR TITLE
Add Font Awesome CDN link to base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>{% block title %}Vehicules{% endblock %}</title>
   <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/litera/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
   <link href="{{ url_for('static', filename='custom.css') }}" rel="stylesheet">
   <link rel="manifest" href="{{ url_for('static', filename='manifest.json') }}">
 </head>


### PR DESCRIPTION
## Summary
- add Font Awesome CDN stylesheet to base template for icon support

## Testing
- `flask --app app --debug run` (curl request to `/login`)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17c234d008330916a46b3bf615c8f