### PR TITLE
Use icon-based card grids on home dashboards

### DIFF
--- a/templates/admin_home.html
+++ b/templates/admin_home.html
@@ -2,10 +2,30 @@
 {% block title %}Administration – Accueil{% endblock %}
 {% block content %}
 <h1 class="h4">Accueil administration</h1>
-<div class="list-group">
-  <a class="list-group-item list-group-item-action" href="{{ url_for('admin_reservations') }}">Gestion des réservations</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('admin_vehicles') }}">Gestion du parc</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Planning mensuel</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Demande de réservation</a>
+<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3">
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('admin_reservations') }}">
+      <i class="fa-solid fa-calendar-check fa-2x mb-2"></i>
+      <h5 class="card-title">Gestion des réservations</h5>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('admin_vehicles') }}">
+      <i class="fa-solid fa-car-side fa-2x mb-2"></i>
+      <h5 class="card-title">Gestion du parc</h5>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('calendar_month') }}">
+      <i class="fa-solid fa-calendar fa-2x mb-2"></i>
+      <h5 class="card-title">Planning mensuel</h5>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('new_request') }}">
+      <i class="fa-solid fa-calendar-plus fa-2x mb-2"></i>
+      <h5 class="card-title">Demande de réservation</h5>
+    </a>
+  </div>
 </div>
 {% endblock %}

--- a/templates/superadmin_home.html
+++ b/templates/superadmin_home.html
@@ -2,12 +2,42 @@
 {% block title %}Superadmin – Accueil{% endblock %}
 {% block content %}
 <h1 class="h4">Accueil administration</h1>
-<div class="list-group">
-  <a class="list-group-item list-group-item-action" href="{{ url_for('admin_users') }}">Gestion des utilisateurs</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('admin_reservations') }}">Gestion des réservations</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('admin_leaves') }}">Gestion des congés</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('admin_vehicles') }}">Gestion du parc</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Planning mensuel</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Demande de réservation</a>
+<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3">
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('admin_users') }}">
+      <i class="fa-solid fa-users fa-2x mb-2"></i>
+      <h5 class="card-title">Gestion des utilisateurs</h5>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('admin_reservations') }}">
+      <i class="fa-solid fa-calendar-check fa-2x mb-2"></i>
+      <h5 class="card-title">Gestion des réservations</h5>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('admin_leaves') }}">
+      <i class="fa-solid fa-plane fa-2x mb-2"></i>
+      <h5 class="card-title">Gestion des congés</h5>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('admin_vehicles') }}">
+      <i class="fa-solid fa-car-side fa-2x mb-2"></i>
+      <h5 class="card-title">Gestion du parc</h5>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('calendar_month') }}">
+      <i class="fa-solid fa-calendar fa-2x mb-2"></i>
+      <h5 class="card-title">Planning mensuel</h5>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('new_request') }}">
+      <i class="fa-solid fa-calendar-plus fa-2x mb-2"></i>
+      <h5 class="card-title">Demande de réservation</h5>
+    </a>
+  </div>
 </div>
 {% endblock %}

--- a/templates/user_home.html
+++ b/templates/user_home.html
@@ -2,9 +2,24 @@
 {% block title %}Accueil utilisateur – Véhicules{% endblock %}
 {% block content %}
 <h1 class="h4">Accueil utilisateur</h1>
-<div class="list-group">
-  <a class="list-group-item list-group-item-action" href="{{ url_for('calendar_month') }}">Planning mensuel</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('new_request') }}">Demande de réservation</a>
-  <a class="list-group-item list-group-item-action" href="{{ url_for('contact') }}">Contact</a>
+<div class="row row-cols-1 row-cols-sm-2 row-cols-lg-3 g-3">
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('calendar_month') }}">
+      <i class="fa-solid fa-calendar fa-2x mb-2"></i>
+      <h5 class="card-title">Planning mensuel</h5>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('new_request') }}">
+      <i class="fa-solid fa-car-side fa-2x mb-2"></i>
+      <h5 class="card-title">Demande de réservation</h5>
+    </a>
+  </div>
+  <div class="col">
+    <a class="card text-center dashboard-card" href="{{ url_for('contact') }}">
+      <i class="fa-solid fa-envelope fa-2x mb-2"></i>
+      <h5 class="card-title">Contact</h5>
+    </a>
+  </div>
 </div>
 {% endblock %}

--- a/tests/test_navigation_links.py
+++ b/tests/test_navigation_links.py
@@ -73,4 +73,4 @@ def test_home_tabs_by_role(role, links):
     html = _render_home(role)
     for link in links:
         assert link in html
-    assert html.count('list-group-item-action') == len(links)
+    assert html.count('dashboard-card') == len(links)


### PR DESCRIPTION
## Summary
- Replace list-group links with responsive card grids on user, admin and superadmin home pages
- Update navigation tests to count dashboard cards instead of list-group items

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c17e3752f08330b238cc356b3a1496