### PR TITLE
test: assert home cards by title

### DIFF
--- a/tests/test_navigation_links.py
+++ b/tests/test_navigation_links.py
@@ -72,5 +72,4 @@ def _render_home(role: str) -> str:
 def test_home_tabs_by_role(role, links):
     html = _render_home(role)
     for link in links:
-        assert link in html
-    assert html.count('dashboard-card') == len(links)
+        assert html.count(f'<h5 class="card-title">{link}</h5>') == 1


### PR DESCRIPTION
## Summary
- ensure home dashboard cards are validated by card title rather than counting CSS classes

## Testing
- `pytest tests/test_navigation_links.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17f4207448330be6472c1c9407ddb