### PR TITLE
Remove team code requirement from registration

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -41,7 +41,6 @@ class RegisterForm(FlaskForm):
             ),
         ],
     )
-    team_code = StringField("Code d'équipe", validators=[DataRequired(), Length(max=60)])
     submit = SubmitField("Créer mon compte")
 
 class NewRequestForm(FlaskForm):

--- a/templates/register.html
+++ b/templates/register.html
@@ -10,7 +10,6 @@
   <div class="mb-3"><label class="form-label">Email (identifiant)</label><input name="email" type="email" class="form-control" required></div>
   <div class="mb-3"><label class="form-label">Mot de passe</label><input name="password" type="password" class="form-control" required minlength="10"><div class="form-text">≥ 10 car., 1 maj, 1 min, 1 chiffre.</div></div>
   <div class="mb-3"><label class="form-label">Confirmer le mot de passe</label><input name="password2" type="password" class="form-control" required minlength="10"></div>
-  <div class="mb-3"><label class="form-label">Code d’équipe</label><input name="team_code" class="form-control" required></div>
   <button class="btn btn-success w-100" type="submit">Créer le compte</button>
 </form>
 <hr class="my-3"><div class="text-center"><a href="{{ url_for('login') }}">Déjà un compte ? Se connecter</a></div>


### PR DESCRIPTION
## Summary
- drop team code field from register form and template

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c18262e1f483308a65baebb7fae781