### PR TITLE
Show user role badge with truncated name

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -45,13 +45,22 @@
 }
 
 .user-name {
+  display: inline-block;
   max-width: 12rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 @media (max-width: 576px) {
   .user-name {
     max-width: 8rem;
   }
+}
+
+.navbar .badge {
+  color: var(--bs-navbar-color);
+  background-color: var(--bs-navbar-bg, var(--bs-secondary)) !important;
 }
 
 /* Dashboard cards and icons */

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,7 +26,12 @@
       </ul>
       <ul class="navbar-nav ms-auto align-items-center">
         {% if user %}
-          <li class="nav-item me-2"><span class="navbar-text">{{ user.first_name }} {{ user.last_name }} — {{ user.role }}</span></li>
+          <li class="nav-item me-2">
+            <span class="navbar-text d-flex align-items-center">
+              <span class="user-name text-truncate">{{ user.first_name }} {{ user.last_name }}</span>
+              <span class="badge bg-secondary ms-1">{{ user.role }}</span>
+            </span>
+          </li>
           <li class="nav-item me-2"><a href="{{ url_for('logout') }}" class="btn btn-danger btn-sm">Déconnexion</a></li>
         {% else %}
           <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('login') }}">Connexion</a></li>


### PR DESCRIPTION
## Summary
- Display user's role as a badge and truncate long names in the navbar
- Add custom CSS for text truncation and badge theming

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c18534da48833094fbaa3e87f2fc84