### PR TITLE
feat(navbar): add profile dropdown

### DIFF
--- a/static/custom.css
+++ b/static/custom.css
@@ -87,3 +87,12 @@
   justify-content: center;
 }
 
+
+.navbar-nav .dropdown-menu {
+  left: auto;
+  right: 0;
+}
+
+.dropdown-item i {
+  margin-right: 0.5rem;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -26,13 +26,19 @@
       </ul>
       <ul class="navbar-nav ms-auto align-items-center">
         {% if user %}
-          <li class="nav-item me-2">
-            <span class="navbar-text d-flex align-items-center">
-              <span class="user-name text-truncate">{{ user.first_name }} {{ user.last_name }}</span>
-              <span class="badge bg-secondary ms-1">{{ user.role }}</span>
-            </span>
-          </li>
-          <li class="nav-item me-2"><a href="{{ url_for('logout') }}" class="btn btn-danger btn-sm">Déconnexion</a></li>
+            <li class="nav-item dropdown me-2">
+              <button class="btn btn-outline-light btn-sm dropdown-toggle d-flex align-items-center" data-bs-toggle="dropdown" aria-expanded="false">
+                <span class="user-name text-truncate">{{ user.first_name }} {{ user.last_name }}</span>
+                <span class="badge bg-secondary ms-1">{{ user.role }}</span>
+              </button>
+              <ul class="dropdown-menu dropdown-menu-end">
+                <li>
+                  <a class="dropdown-item d-flex align-items-center" href="{{ url_for('logout') }}">
+                    <i class="fa-solid fa-right-from-bracket me-2"></i>Déconnexion
+                  </a>
+                </li>
+              </ul>
+            </li>
         {% else %}
           <li class="nav-item me-2"><a class="nav-link" href="{{ url_for('login') }}">Connexion</a></li>
         {% endif %}


### PR DESCRIPTION
## Summary
- replace logout button with profile dropdown showing user name
- style dropdown toggle and add logout item with right-from-bracket icon
- tweak custom CSS for dropdown alignment and icon spacing

## Testing
- `pytest` *(fails: /usr/bin/pytest: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c18647b3cc8330b994d7438c1028f0