### PR TITLE
Add database backup script and daily timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,18 @@ Lorsqu'une journée d'une réservation sur plusieurs jours est segmentée vers u
 ## Contact
 
 Les utilisateurs connectés disposent d'un onglet **Contact** permettant d'envoyer un message aux administrateurs. Les destinataires sont définis via les paramètres de notification et chaque expéditeur reçoit un e‑mail de confirmation.
+
+## Sauvegarde et restauration
+
+Une tâche planifiée exécute `tools/backup_db.sh` chaque jour pour sauvegarder `vehicules.db` et conserver 30 jours d'historique.
+
+Pour restaurer une sauvegarde :
+
+1. Décompressez le fichier si nécessaire :
+   ```bash
+   gzip -d backups/vehicules_YYYYMMDD_HHMMSS.db.gz
+   ```
+2. Restaurez la base :
+   ```bash
+   sqlite3 vehicules.db ".restore 'backups/vehicules_YYYYMMDD_HHMMSS.db'"
+   ```

--- a/tools/backup_db.service
+++ b/tools/backup_db.service
@@ -1,0 +1,7 @@
+[Unit]
+Description=Sauvegarde de la base Vehicules
+
+[Service]
+Type=oneshot
+WorkingDirectory=/path/to/vehicules
+ExecStart=/usr/bin/env bash tools/backup_db.sh

--- a/tools/backup_db.sh
+++ b/tools/backup_db.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BACKUP_DIR="backups"
+mkdir -p "$BACKUP_DIR"
+
+TS="$(date +%Y%m%d_%H%M%S)"
+DB_FILE="$BACKUP_DIR/vehicules_${TS}.db"
+
+sqlite3 vehicules.db ".backup '$DB_FILE'"
+
+if [ "${COMPRESS:-true}" = "true" ]; then
+  gzip "$DB_FILE"
+  DB_FILE="${DB_FILE}.gz"
+fi
+
+if [ -n "${REMOTE_URI:-}" ]; then
+  # Exemple : scp "$DB_FILE" "$REMOTE_URI"
+  # Exemple : aws s3 cp "$DB_FILE" "$REMOTE_URI"
+  :
+fi
+
+find "$BACKUP_DIR" -type f -mtime +30 -name 'vehicules_*' -delete

--- a/tools/backup_db.timer
+++ b/tools/backup_db.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Exécution quotidienne de la sauvegarde de la base Vehicules
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
- add `backup_db.sh` to dump `vehicules.db`, compress, purge old copies
- schedule backups with systemd service and daily timer
- document how to restore backups in the README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c18c43332483309b6a05dfa2afb9a6