### PR TITLE
Add rclone-based Google Drive backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,14 +41,23 @@ Les utilisateurs connectés disposent d'un onglet **Contact** permettant d'envoy
 ## Sauvegarde et restauration
 
 Une tâche planifiée exécute `tools/backup_db.sh` chaque jour pour sauvegarder `vehicules.db` et conserver 30 jours d'historique.
+Le script envoie automatiquement la sauvegarde vers Google Drive avec
+[`rclone`](https://rclone.org/).
 
-Pour restaurer une sauvegarde :
+### Installation et configuration de rclone
 
-1. Décompressez le fichier si nécessaire :
-   ```bash
-   gzip -d backups/vehicules_YYYYMMDD_HHMMSS.db.gz
-   ```
-2. Restaurez la base :
-   ```bash
-   sqlite3 vehicules.db ".restore 'backups/vehicules_YYYYMMDD_HHMMSS.db'"
-   ```
+```bash
+sudo apt-get install rclone
+rclone config    # créer le remote « gdrive » de type Google Drive
+```
+
+### Restaurer depuis Google Drive
+
+```bash
+# Télécharger la sauvegarde depuis Drive
+rclone copy gdrive:vehicules-backups/vehicules_YYYYMMDD_HHMMSS.db.gz backups/
+
+# Décompresser puis restaurer dans SQLite
+gzip -d backups/vehicules_YYYYMMDD_HHMMSS.db.gz
+sqlite3 vehicules.db ".restore 'backups/vehicules_YYYYMMDD_HHMMSS.db'"
+```

--- a/tools/backup_db.service
+++ b/tools/backup_db.service
@@ -4,4 +4,5 @@ Description=Sauvegarde de la base Vehicules
 [Service]
 Type=oneshot
 WorkingDirectory=/path/to/vehicules
+Environment=REMOTE_URI=gdrive:vehicules-backups
 ExecStart=/usr/bin/env bash tools/backup_db.sh

--- a/tools/backup_db.sh
+++ b/tools/backup_db.sh
@@ -15,9 +15,7 @@ if [ "${COMPRESS:-true}" = "true" ]; then
 fi
 
 if [ -n "${REMOTE_URI:-}" ]; then
-  # Exemple : scp "$DB_FILE" "$REMOTE_URI"
-  # Exemple : aws s3 cp "$DB_FILE" "$REMOTE_URI"
-  :
+  rclone copy "$DB_FILE" "$REMOTE_URI"
 fi
 
 find "$BACKUP_DIR" -type f -mtime +30 -name 'vehicules_*' -delete


### PR DESCRIPTION
## Summary
- Upload backups to a configured remote via rclone
- Provide systemd service environment for Google Drive backups
- Document rclone setup and restoring from Drive

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c19363ef3c83308237715f9c1aa10f