### PR TITLE
Configure backup service working directory

### DIFF
--- a/tools/backup_db.service
+++ b/tools/backup_db.service
@@ -3,6 +3,6 @@ Description=Sauvegarde de la base Vehicules
 
 [Service]
 Type=oneshot
-WorkingDirectory=/path/to/vehicules
+WorkingDirectory=/workspace/vehicules
 Environment=REMOTE_URI=gdrive:vehicules-backups
 ExecStart=/usr/bin/env bash tools/backup_db.sh


### PR DESCRIPTION
## Summary
- point backup_db.service to run from the project root

## Testing
- `pytest`
- `sudo systemctl enable --now backup_db.timer` *(fails: System has not been booted with systemd as init system)*
- `REMOTE_URI=gdrive:vehicules-backups tools/backup_db.sh` *(fails: empty OAuth token; run `rclone config reconnect gdrive:`)*
- `rclone ls gdrive:vehicules-backups` *(fails: empty OAuth token; run `rclone config reconnect gdrive:`)*

------
https://chatgpt.com/codex/tasks/task_e_68c19688d93c83308446fc9a5f6050e9