### PR TITLE
Implement token-based password reset flow

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -43,6 +43,23 @@ class RegisterForm(FlaskForm):
     )
     submit = SubmitField("Créer mon compte")
 
+
+class ResetPasswordForm(FlaskForm):
+    password = PasswordField(
+        "Nouveau mot de passe", validators=[DataRequired(), Length(min=8)]
+    )
+    password2 = PasswordField(
+        "Confirmer le mot de passe",
+        validators=[
+            DataRequired(),
+            EqualTo(
+                "password",
+                message="Les mots de passe doivent correspondre.",
+            ),
+        ],
+    )
+    submit = SubmitField("Enregistrer")
+
 class NewRequestForm(FlaskForm):
     first_name = StringField("Prénom", validators=[DataRequired(), Length(max=60)])
     last_name = StringField("Nom", validators=[DataRequired(), Length(max=60)])

--- a/templates/reset_password.html
+++ b/templates/reset_password.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Réinitialiser le mot de passe – Véhicules{% endblock %}
+{% block content %}
+<div class="card mx-auto max-w-420">
+  <div class="card-body">
+    <h5 class="card-title mb-3">Nouveau mot de passe</h5>
+    <form method="post">
+      {{ form.hidden_tag() }}
+      <div class="mb-3">{{ form.password.label(class="form-label") }} {{ form.password(class="form-control") }}</div>
+      <div class="mb-3">{{ form.password2.label(class="form-label") }} {{ form.password2(class="form-control") }}</div>
+      {{ form.submit(class="btn btn-primary w-100") }}
+    </form>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Replace admin password reset with token generation and email link
- Add user token utilities, reset route, form and template
- Allow unauthenticated access to password reset endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c567dc273c833091e1d14ae2557e6f