### PR TITLE
Allow admins to remove reservations and associated segments

### DIFF
--- a/app.py
+++ b/app.py
@@ -773,6 +773,11 @@ def manage_request(rid):
             db.session.commit()
             flash("Demande refusée.", "warning")
             return redirect(url_for("admin_reservations"))
+        elif action == "delete":
+            db.session.delete(r)
+            db.session.commit()
+            flash("Réservation supprimée.", "info")
+            return redirect(url_for("admin_reservations"))
     avail = vehicles_availability(day_start, day_end)
     user = current_user()
     return render_template(

--- a/models.py
+++ b/models.py
@@ -63,6 +63,11 @@ class Reservation(db.Model):
 
     vehicle = db.relationship("Vehicle", backref="reservations")
     user = db.relationship("User", backref="reservations")
+    segments = db.relationship(
+        "ReservationSegment",
+        back_populates="reservation",
+        cascade="all, delete-orphan",
+    )
 
 
 class ReservationSegment(db.Model):
@@ -76,8 +81,8 @@ class ReservationSegment(db.Model):
     start_at = db.Column(db.DateTime, nullable=False)
     end_at = db.Column(db.DateTime, nullable=False)
 
-    reservation = db.relationship('Reservation', backref='segments')
-    vehicle = db.relationship('Vehicle')
+    reservation = db.relationship("Reservation", back_populates="segments")
+    vehicle = db.relationship("Vehicle")
 
 
 class NotificationSettings(db.Model):

--- a/templates/admin_reservations.html
+++ b/templates/admin_reservations.html
@@ -19,7 +19,13 @@
           {% elif r.status=='rejected' %}<span class="badge bg-secondary">refusée</span>
           {% else %}<span class="badge bg-warning text-dark">en attente</span>{% endif %}
         </td>
-        <td class="text-end"><a class="btn btn-sm btn-primary" href="{{ url_for('manage_request', rid=r.id) }}">Gérer</a></td>
+        <td class="text-end">
+          <a class="btn btn-sm btn-primary" href="{{ url_for('manage_request', rid=r.id) }}">Gérer</a>
+          <form method="post" action="{{ url_for('manage_request', rid=r.id) }}" class="d-inline">
+            <input type="hidden" name="action" value="delete">
+            <button class="btn btn-sm btn-outline-danger" onclick="return confirm('Supprimer cette réservation ?');">Supprimer</button>
+          </form>
+        </td>
       </tr>
     {% else %}
       <tr><td colspan="7">Aucune réservation.</td></tr>

--- a/templates/manage_request.html
+++ b/templates/manage_request.html
@@ -45,6 +45,10 @@
   <button name="action" value="reject"  class="btn btn-outline-danger">Refuser</button>
 </form>
 
+<form method="post" class="mt-2">
+  <button name="action" value="delete" class="btn btn-danger" onclick="return confirm('Supprimer cette réservation ?');">Supprimer la réservation</button>
+</form>
+
 {% if day %}
 <hr/>
 <h2 class="h6">Segmenter la journée du {{ day.strftime('%d/%m/%Y') }}</h2>

--- a/tests/test_reservation_delete.py
+++ b/tests/test_reservation_delete.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import pytest
+from datetime import datetime
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app
+from models import db, User, Vehicle, Reservation, ReservationSegment
+
+
+@pytest.fixture
+def app_ctx():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        yield
+        db.drop_all()
+
+
+def create_user(role=User.ROLE_USER):
+    u = User(
+        name='User',
+        first_name='U',
+        last_name='Ser',
+        email=f'user{role}@example.com',
+        role=role,
+        password_hash='x',
+        status='active',
+    )
+    db.session.add(u)
+    db.session.commit()
+    return u
+
+
+def test_delete_reservation_removes_segments(app_ctx):
+    admin = create_user(role=User.ROLE_ADMIN)
+    user = create_user()
+    v1 = Vehicle(code='V1', label='Vehicule 1')
+    v2 = Vehicle(code='V2', label='Vehicule 2')
+    db.session.add_all([v1, v2])
+    db.session.commit()
+    r = Reservation(
+        vehicle_id=v1.id,
+        user_id=user.id,
+        start_at=datetime(2024, 1, 1, 8),
+        end_at=datetime(2024, 1, 1, 12),
+        status='approved',
+    )
+    db.session.add(r)
+    db.session.commit()
+    seg1 = ReservationSegment(
+        reservation_id=r.id,
+        vehicle_id=v1.id,
+        start_at=datetime(2024, 1, 1, 8),
+        end_at=datetime(2024, 1, 1, 10),
+    )
+    seg2 = ReservationSegment(
+        reservation_id=r.id,
+        vehicle_id=v2.id,
+        start_at=datetime(2024, 1, 1, 10),
+        end_at=datetime(2024, 1, 1, 12),
+    )
+    db.session.add_all([seg1, seg2])
+    db.session.commit()
+
+    client = app.test_client()
+    with client.session_transaction() as sess:
+        sess['uid'] = admin.id
+    data = {'action': 'delete'}
+    client.post(f'/admin/manage/{r.id}', data=data)
+
+    assert Reservation.query.get(r.id) is None
+    assert ReservationSegment.query.filter_by(reservation_id=r.id).count() == 0


### PR DESCRIPTION
## Summary
- allow admins to delete reservations from manage route
- cascade reservation deletion to associated segments
- expose delete buttons in admin templates
- test reservation deletion removes segments

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c56a876d6c8330a8dd5282bf130641