### PR TITLE
Augment contact email body with sender details

### DIFF
--- a/app.py
+++ b/app.py
@@ -363,10 +363,17 @@ def contact():
             ]
         if recipients:
             recipients = list(set(recipients))
+            u = current_user()
+            body_admin = (
+                f"{form.message.data}\n\n"
+                f"Nom : {u.last_name}\n"
+                f"Prénom : {u.first_name}\n"
+                f"Email : {u.email}"
+            )
             try:
                 send_mail_msmtp(
                     "Message de contact",
-                    form.message.data,
+                    body_admin,
                     recipients,
                 )
             except Exception:

--- a/tests/test_contact.py
+++ b/tests/test_contact.py
@@ -75,10 +75,14 @@ def test_contact_sends_emails(monkeypatch):
         client.post('/contact', data={'message': 'Hello'}, follow_redirects=True)
 
         assert len(calls) == 2
+        body_admin = calls[0][1]
         rec1 = calls[0][2]
         rec2 = calls[1][2]
         rec1_set = set(rec1 if isinstance(rec1, (list, set)) else [rec1])
         rec2_set = set(rec2 if isinstance(rec2, (list, set)) else [rec2])
         assert rec1_set == {admin.email}
         assert rec2_set == {user.email}
+        assert user.first_name in body_admin
+        assert user.last_name in body_admin
+        assert user.email in body_admin
         db.drop_all()


### PR DESCRIPTION
## Summary
- include the sender's identity in the contact email sent to administrators
- extend the contact email test to assert the sender details are present in the admin email body

## Testing
- PYTHONPATH=. pytest tests/test_contact.py

------
https://chatgpt.com/codex/tasks/task_e_68c9676df0948330a3b4f4c799ea1b55