### PR TITLE
Affiche les jours en français dans le calendrier mensuel

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import locale
 import os
 import sys
 from urllib.parse import quote as _urlquote
@@ -58,6 +59,33 @@ app = Flask(__name__)
 app.config.from_object(Config)
 db.init_app(app)
 Migrate(app, db)
+
+try:
+    locale.setlocale(locale.LC_TIME, "fr_FR.UTF-8")
+except locale.Error:
+    try:
+        locale.setlocale(locale.LC_TIME, "fr_FR")
+    except locale.Error:
+        pass
+
+_FRENCH_WEEKDAY_ABBRS = ("lun", "mar", "mer", "jeu", "ven", "sam", "dim")
+_FRENCH_WEEKDAY_SET = set(_FRENCH_WEEKDAY_ABBRS)
+
+
+def _weekday_abbr(dt):
+    if not dt:
+        return ""
+    label = dt.strftime("%a")
+    if label:
+        normalized = label.lower().strip(".")
+        if normalized in _FRENCH_WEEKDAY_SET:
+            return normalized
+    return _FRENCH_WEEKDAY_ABBRS[dt.weekday()]
+
+
+@app.context_processor
+def _inject_locale_helpers():
+    return {"weekday_abbr": _weekday_abbr}
 
 
 def purge_expired_requests():

--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -22,7 +22,10 @@
     <tr>
       <th class="sticky-col">Véhicule</th>
       {% for i in range(days) %}
-        <th class="text-center">{{ (start + timedelta(days=(i|int))).strftime("%d") }}</th>
+        {% set day = start + timedelta(days=(i|int)) %}
+        <th class="text-center">
+          <div class="calendar-day-header">{{ weekday_abbr(day) }}<br>{{ day.day }}</div>
+        </th>
       {% endfor %}
     </tr>
   </thead>


### PR DESCRIPTION
## Summary
- initialise la locale française pour le formatage des dates et expose un utilitaire retournant les abréviations des jours en français
- met à jour l’en-tête du planning mensuel pour afficher l’abréviation du jour au-dessus du numéro

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9699c1ed88330b1c10ec5229c2102