### PR TITLE
Ensure French month names in calendar views

### DIFF
--- a/app.py
+++ b/app.py
@@ -70,6 +70,35 @@ except locale.Error:
 
 _FRENCH_WEEKDAY_ABBRS = ("lun", "mar", "mer", "jeu", "ven", "sam", "dim")
 _FRENCH_WEEKDAY_SET = set(_FRENCH_WEEKDAY_ABBRS)
+_FRENCH_MONTH_BY_NUMBER = {
+    1: "janvier",
+    2: "février",
+    3: "mars",
+    4: "avril",
+    5: "mai",
+    6: "juin",
+    7: "juillet",
+    8: "août",
+    9: "septembre",
+    10: "octobre",
+    11: "novembre",
+    12: "décembre",
+}
+_FRENCH_MONTH_NAMES = set(_FRENCH_MONTH_BY_NUMBER.values())
+_ENGLISH_TO_FRENCH_MONTHS = {
+    "january": "janvier",
+    "february": "février",
+    "march": "mars",
+    "april": "avril",
+    "may": "mai",
+    "june": "juin",
+    "july": "juillet",
+    "august": "août",
+    "september": "septembre",
+    "october": "octobre",
+    "november": "novembre",
+    "december": "décembre",
+}
 
 
 def _weekday_abbr(dt):
@@ -83,9 +112,23 @@ def _weekday_abbr(dt):
     return _FRENCH_WEEKDAY_ABBRS[dt.weekday()]
 
 
+def _month_year_label(dt):
+    if not dt:
+        return ""
+    month_name = dt.strftime("%B") or ""
+    normalized = month_name.strip().lower()
+    if normalized in _FRENCH_MONTH_NAMES:
+        month = normalized
+    else:
+        month = _ENGLISH_TO_FRENCH_MONTHS.get(normalized)
+        if not month:
+            month = _FRENCH_MONTH_BY_NUMBER.get(dt.month, normalized)
+    return f"{month} {dt.year}" if month else dt.strftime("%B %Y")
+
+
 @app.context_processor
 def _inject_locale_helpers():
-    return {"weekday_abbr": _weekday_abbr}
+    return {"weekday_abbr": _weekday_abbr, "month_year_label": _month_year_label}
 
 
 def purge_expired_requests():

--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -12,7 +12,7 @@
 <h1 class="h4">Planning mensuel (lecture seule)</h1>
 <p>
   <a href="{{ url_for('calendar_month', y=prev_y, m=prev_m) }}">&larr;</a>
-  Mois: {{ start.strftime('%B %Y') }}
+  Mois: {{ month_year_label(start) }}
   <a href="{{ url_for('calendar_month', y=next_y, m=next_m) }}">&rarr;</a>
 </p>
 {% set days = (end - start).days %}

--- a/templates/pdf_month.html
+++ b/templates/pdf_month.html
@@ -7,7 +7,7 @@ body{font-family:sans-serif;font-size:11px}
 table{width:100%;border-collapse:collapse}th,td{border:1px solid #999;padding:3px;vertical-align:top;text-align:center}
 th.sticky, td.sticky{position:sticky;left:0;background:#fff}
 </style></head><body>
-<h1>Planning véhicules — {{ start.strftime("%B %Y") }}</h1>
+<h1>Planning véhicules — {{ month_year_label(start) }}</h1>
 {% set days = (end - start).days %}
 <div class="table-responsive">
 <table>


### PR DESCRIPTION
## Summary
- add a locale-aware helper that always returns French month names using strftime with a fallback mapping
- expose the helper to templates and use it in the calendar and PDF month headers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c96cf8dcc0833087c2b42062996653