### PR TITLE
Add credential options and error handling to backup script

### DIFF
--- a/tools/backup_db.sh
+++ b/tools/backup_db.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Environment variables:
+#   COMPRESS                 Whether to gzip the backup (default: true).
+#   REMOTE_URI               rclone destination to receive the backup (optional).
+#   RCLONE_CONFIG            Path to a custom rclone configuration file (optional).
+#   GDRIVE_SERVICE_ACCOUNT   Path to a Google Drive service account JSON file (optional).
+
 BACKUP_DIR="backups"
 mkdir -p "$BACKUP_DIR"
 
@@ -15,7 +21,18 @@ if [ "${COMPRESS:-true}" = "true" ]; then
 fi
 
 if [ -n "${REMOTE_URI:-}" ]; then
-  rclone copy "$DB_FILE" "$REMOTE_URI"
+  RCLONE_ARGS=()
+  if [ -n "${RCLONE_CONFIG:-}" ]; then
+    RCLONE_ARGS+=("--config" "$RCLONE_CONFIG")
+  fi
+  if [ -n "${GDRIVE_SERVICE_ACCOUNT:-}" ]; then
+    RCLONE_ARGS+=("--drive-service-account-file" "$GDRIVE_SERVICE_ACCOUNT")
+  fi
+
+  if ! rclone "${RCLONE_ARGS[@]}" copy "$DB_FILE" "$REMOTE_URI"; then
+    echo "Error: failed to copy backup to remote destination '$REMOTE_URI'" >&2
+    exit 1
+  fi
 fi
 
 find "$BACKUP_DIR" -type f -mtime +30 -name 'vehicules_*' -delete


### PR DESCRIPTION
## Summary
- document the backup script environment variables for providing rclone credentials
- pass optional RCLONE_CONFIG and GDRIVE_SERVICE_ACCOUNT values to the rclone copy command
- fail fast with a clear error message if the remote upload cannot be completed

## Testing
- bash -n tools/backup_db.sh

------
https://chatgpt.com/codex/tasks/task_e_68c972e4a87c833087192b1069782380