### PR TITLE
Add rclone config environment to backup service

### DIFF
--- a/tools/backup_db.service
+++ b/tools/backup_db.service
@@ -5,4 +5,5 @@ Description=Sauvegarde de la base Vehicules
 Type=oneshot
 WorkingDirectory=/workspace/vehicules
 Environment=REMOTE_URI=gdrive:vehicules-backups
+Environment=RCLONE_CONFIG=/path/to/rclone.conf
 ExecStart=/usr/bin/env bash tools/backup_db.sh


### PR DESCRIPTION
## Summary
- add the RCLONE_CONFIG environment variable to the backup systemd unit so the service can locate a custom rclone configuration file

## Testing
- systemctl daemon-reload *(fails in container: systemd not available)*

------
https://chatgpt.com/codex/tasks/task_e_68c973a94b9083309e1894dbab238e53