### PR TITLE
Add owner signature markers

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@
 import locale
 import os
 import sys
+# Signature: AS-2024-6f9e3c42
 from urllib.parse import quote as _urlquote
 from functools import wraps
 from flask import (

--- a/config.py
+++ b/config.py
@@ -2,6 +2,9 @@
 import os
 
 
+OWNER_SIGNATURE = "AS-2024-6f9e3c42"
+
+
 class Config:
     SECRET_KEY = os.environ.get("SECRET_KEY","change-me")
     SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL","sqlite:///vehicules.db")


### PR DESCRIPTION
## Summary
- add a discrete signature comment near the top-level imports in `app.py`
- define an `OWNER_SIGNATURE` constant in `config.py` for traceability

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c98a3338dc8330b590fefc5570ff0f