### PR TITLE
Add carpool suggestions API and UI enhancements

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -9,6 +9,7 @@ from wtforms import (
     TextAreaField,
     SelectField,
     SelectMultipleField,
+    HiddenField,
 )
 from wtforms.validators import DataRequired, Email, Length, EqualTo, Optional
 from wtforms.widgets import CheckboxInput, ListWidget
@@ -94,6 +95,7 @@ class NewRequestForm(FlaskForm):
     purpose = StringField("Motif", validators=[Length(max=200)])
     carpool = BooleanField("Covoiturage")
     carpool_with = StringField("Avec qui")
+    carpool_with_ids = HiddenField()
     notes = TextAreaField("Précisions", validators=[Length(max=1000)])
     submit = SubmitField("Envoyer la demande")
 

--- a/migrations/versions/c2d3e4f5a6b7_add_carpool_with_ids.py
+++ b/migrations/versions/c2d3e4f5a6b7_add_carpool_with_ids.py
@@ -1,0 +1,23 @@
+"""add carpool_with_ids to reservation
+
+Revision ID: c2d3e4f5a6b7
+Revises: b9f8d1e7e3c9
+Create Date: 2024-08-20 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'c2d3e4f5a6b7'
+down_revision = 'b9f8d1e7e3c9'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('reservation', sa.Column('carpool_with_ids', sa.JSON(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('reservation', 'carpool_with_ids')

--- a/models.py
+++ b/models.py
@@ -57,6 +57,7 @@ class Reservation(db.Model):
     purpose = db.Column(db.String(200), nullable=True)
     carpool = db.Column(db.Boolean, default=False)
     carpool_with = db.Column(db.String(200), nullable=True)
+    carpool_with_ids = db.Column(db.JSON, default=list)
     notes = db.Column(db.Text, nullable=True)
     status = db.Column(db.String(20), default="pending")  # pending/approved/rejected
     created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/templates/new_request.html
+++ b/templates/new_request.html
@@ -32,7 +32,13 @@
       </div>
       <div class="mb-3">{{ form.purpose.label(class="form-label") }} {{ form.purpose(class="form-control") }}</div>
       <div class="form-check mb-3">{{ form.carpool(class="form-check-input") }} {{ form.carpool.label(class="form-check-label") }}</div>
-      <div class="mb-3">{{ form.carpool_with.label(class="form-label") }} {{ form.carpool_with(class="form-control") }}</div>
+      <div class="mb-3">
+        {{ form.carpool_with.label(class="form-label") }}
+        {{ form.carpool_with(class="form-control", list="carpool_suggestions", autocomplete="off") }}
+        <datalist id="carpool_suggestions"></datalist>
+        {{ form.carpool_with_ids(id="carpool_with_ids") }}
+        <div id="carpool_selected" class="mt-2 d-none"></div>
+      </div>
       <div class="mb-3">{{ form.notes.label(class="form-label") }} {{ form.notes(class="form-control", rows=3) }}</div>
       {{ form.submit(class="btn btn-success") }}
     </form>
@@ -43,6 +49,10 @@
   const endFields = document.getElementById('end_fields');
   const endDateInput = document.getElementById('end_date');
   const endSlotSelect = document.getElementById('end_slot');
+  const carpoolInput = document.getElementById('carpool_with');
+  const carpoolHidden = document.getElementById('carpool_with_ids');
+  const carpoolDatalist = document.getElementById('carpool_suggestions');
+  const carpoolSelected = document.getElementById('carpool_selected');
   function toggleEndFields() {
     const enabled = multiDay.checked;
     endFields.classList.toggle('d-none', !enabled);
@@ -54,5 +64,164 @@
   }
   multiDay.addEventListener('change', toggleEndFields);
   toggleEndFields();
+
+  let currentResults = [];
+  let selectedUsers = [];
+  let fetchController = null;
+
+  function syncSelectedDisplay() {
+    if (!Array.isArray(selectedUsers)) {
+      selectedUsers = [];
+    }
+    carpoolHidden.value = JSON.stringify(selectedUsers);
+    carpoolSelected.innerHTML = '';
+    if (selectedUsers.length === 0) {
+      carpoolSelected.classList.add('d-none');
+      return;
+    }
+    carpoolSelected.classList.remove('d-none');
+    selectedUsers.forEach((user, index) => {
+      const badge = document.createElement('span');
+      badge.className = 'badge bg-light text-dark border me-2 mb-2 d-inline-flex align-items-center';
+      const label = document.createElement('span');
+      label.textContent = user.label;
+      badge.appendChild(label);
+      const removeButton = document.createElement('button');
+      removeButton.type = 'button';
+      removeButton.className = 'btn btn-sm btn-link text-danger ms-2 p-0';
+      removeButton.setAttribute('aria-label', 'Retirer');
+      removeButton.innerHTML = '&times;';
+      removeButton.addEventListener('click', () => {
+        selectedUsers.splice(index, 1);
+        syncSelectedDisplay();
+      });
+      badge.appendChild(removeButton);
+      carpoolSelected.appendChild(badge);
+    });
+  }
+
+  function addSelectedUser(user) {
+    if (!user || !user.label) {
+      return;
+    }
+    if (user.id !== null && user.id !== undefined) {
+      const exists = selectedUsers.some((entry) => entry.id === user.id);
+      if (exists) {
+        return;
+      }
+    }
+    selectedUsers.push({ id: user.id ?? null, label: user.label });
+    syncSelectedDisplay();
+  }
+
+  function commitCurrentValue() {
+    const value = carpoolInput.value.trim();
+    if (!value) {
+      carpoolInput.value = '';
+      return;
+    }
+    const normalized = value.toLowerCase();
+    const match = currentResults.find((user) => user.label && user.label.toLowerCase() === normalized);
+    if (match) {
+      addSelectedUser({ id: match.id, label: match.label });
+    } else {
+      addSelectedUser({ id: null, label: value });
+    }
+    carpoolInput.value = '';
+    currentResults = [];
+    carpoolDatalist.innerHTML = '';
+  }
+
+  function updateSuggestions(results) {
+    currentResults = Array.isArray(results) ? results : [];
+    carpoolDatalist.innerHTML = '';
+    currentResults.forEach((user) => {
+      if (!user || !user.label) {
+        return;
+      }
+      const option = document.createElement('option');
+      option.value = user.label;
+      carpoolDatalist.appendChild(option);
+    });
+  }
+
+  async function fetchSuggestions(query) {
+    if (fetchController) {
+      fetchController.abort();
+    }
+    fetchController = new AbortController();
+    try {
+      const response = await fetch(`/api/users/search?q=${encodeURIComponent(query)}`, {
+        signal: fetchController.signal,
+      });
+      if (!response.ok) {
+        updateSuggestions([]);
+        return;
+      }
+      const payload = await response.json();
+      updateSuggestions(payload);
+    } catch (err) {
+      if (err.name !== 'AbortError') {
+        console.error('Unable to fetch suggestions', err);
+      }
+    }
+  }
+
+  carpoolInput.addEventListener('input', (event) => {
+    const term = event.target.value.trim();
+    if (term.length < 2) {
+      updateSuggestions([]);
+      return;
+    }
+    fetchSuggestions(term);
+  });
+
+  carpoolInput.addEventListener('change', () => {
+    commitCurrentValue();
+  });
+
+  carpoolInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ',') {
+      event.preventDefault();
+      commitCurrentValue();
+    }
+  });
+
+  carpoolInput.addEventListener('blur', () => {
+    commitCurrentValue();
+  });
+
+  const formElement = carpoolInput.closest('form');
+  if (formElement) {
+    formElement.addEventListener('submit', () => {
+      syncSelectedDisplay();
+      const labels = selectedUsers.map((user) => user.label).join(', ');
+      carpoolInput.value = labels;
+    });
+  }
+
+  function initializeSelectedFromHidden() {
+    let raw = carpoolHidden.value;
+    if (!raw) {
+      raw = '[]';
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        selectedUsers = parsed
+          .filter((entry) => entry && typeof entry.label === 'string' && entry.label.trim() !== '')
+          .map((entry) => ({
+            id: entry.id ?? null,
+            label: entry.label.trim(),
+          }));
+      }
+    } catch (err) {
+      selectedUsers = [];
+    }
+    syncSelectedDisplay();
+    carpoolInput.value = '';
+  }
+
+  initializeSelectedFromHidden();
 </script>
 {% endblock %}

--- a/tests/test_user_search_api.py
+++ b/tests/test_user_search_api.py
@@ -1,0 +1,63 @@
+import pytest
+
+from app import app
+from models import db, User
+
+
+def create_user(first_name, last_name, email, role=User.ROLE_USER, status='active'):
+    return User(
+        name=f"{last_name} {first_name}".strip(),
+        first_name=first_name,
+        last_name=last_name,
+        email=email,
+        role=role,
+        password_hash='x',
+        status=status,
+    )
+
+
+def setup_app():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+
+
+def test_search_users_returns_matches_and_excludes_current_user():
+    setup_app()
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+        current = create_user('Charlie', 'Current', 'current@example.com')
+        match_one = create_user('Alice', 'Martin', 'alice@example.com')
+        match_two = create_user('Alfred', 'Dupont', 'alfred@example.com')
+        other = create_user('Zoé', 'Brun', 'zoe@example.com')
+        inactive = create_user('Alan', 'Inactive', 'inactive@example.com', status='pending')
+        db.session.add_all([current, match_one, match_two, other, inactive])
+        db.session.commit()
+
+        client = app.test_client()
+        with client.session_transaction() as sess:
+            sess['uid'] = current.id
+
+        response = client.get('/api/users/search?q=al')
+        assert response.status_code == 200
+        payload = response.get_json()
+        labels = {entry['label'] for entry in payload}
+        ids = {entry['id'] for entry in payload}
+
+        assert match_one.id in ids
+        assert match_two.id in ids
+        assert 'Alice Martin' in labels
+        assert 'Alfred Dupont' in labels
+        assert current.id not in ids
+        assert inactive.id not in ids
+        assert other.id not in ids
+
+        # empty search should return no suggestions
+        empty_response = client.get('/api/users/search?q=')
+        assert empty_response.status_code == 200
+        assert empty_response.get_json() == []
+
+        db.drop_all()
+


### PR DESCRIPTION
## Summary
- add a JSON column for carpool participant identifiers and create the matching Alembic migration
- expose `/api/users/search` to return active user suggestions while ensuring the default SQLite location exists
- enhance the new reservation form with datalist-driven suggestions that maintain readable names and hidden identifiers
- extend the new request handling to persist parsed carpool identifiers alongside the labels
- cover the user search API with a dedicated test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cac8e157cc83308089ee4bf6e1e54a