### PR TITLE
Include carpoolers in reservation notifications

### DIFF
--- a/migrations/versions/d7a9c8b12345_add_carpool_with_details.py
+++ b/migrations/versions/d7a9c8b12345_add_carpool_with_details.py
@@ -1,0 +1,24 @@
+"""add carpool_with_details to reservation
+
+Revision ID: d7a9c8b12345
+Revises: c2d3e4f5a6b7
+Create Date: 2024-08-20 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd7a9c8b12345'
+down_revision = 'c2d3e4f5a6b7'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('reservation', sa.Column('carpool_with_details', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('reservation', 'carpool_with_details')

--- a/models.py
+++ b/models.py
@@ -58,6 +58,7 @@ class Reservation(db.Model):
     carpool = db.Column(db.Boolean, default=False)
     carpool_with = db.Column(db.String(200), nullable=True)
     carpool_with_ids = db.Column(db.JSON, default=list)
+    carpool_with_details = db.Column(db.JSON, default=list)
     notes = db.Column(db.Text, nullable=True)
     status = db.Column(db.String(20), default="pending")  # pending/approved/rejected
     created_at = db.Column(db.DateTime, default=datetime.utcnow)

--- a/tests/test_segments.py
+++ b/tests/test_segments.py
@@ -276,8 +276,12 @@ def test_segment_update_sends_mail(app_ctx, monkeypatch):
 
     called = {}
 
-    def fake_send_mail(subject, body, to_addr):
-        called["args"] = (subject, body, to_addr)
+    def fake_send_mail(subject, body, to_addr, sender="gestionvehiculestomer@gmail.com", profile="gmail"):
+        if isinstance(to_addr, str):
+            recipients = [to_addr]
+        else:
+            recipients = list(to_addr)
+        called["args"] = (subject, body, recipients)
         return True, "sent"
 
     monkeypatch.setattr("app.send_mail_msmtp", fake_send_mail)
@@ -291,7 +295,7 @@ def test_segment_update_sends_mail(app_ctx, monkeypatch):
     assert ReservationSegment.query.get(seg.id).vehicle_id == v2.id
     subject, body, to_addr = called["args"]
     assert subject == "Modification de votre réservation"
-    assert to_addr == user.email
+    assert to_addr == [user.email]
     assert "Vehicule 1" in body
     assert "Vehicule 2" in body
     assert "01/01/2024 08:00" in body


### PR DESCRIPTION
## Summary
- store structured carpooler details alongside reservations when a request lists covoitureurs
- reuse those details to build deduplicated recipient lists that include active carpoolers for approval and segment notification emails
- add migration and tests covering approval and vehicle-change flows for covoitureur notifications

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cacb8ea2788330bdea81b14a409ade