### PR TITLE
Improve admin user selection fallback

### DIFF
--- a/templates/new_request.html
+++ b/templates/new_request.html
@@ -80,9 +80,18 @@
   if (adminUserInput && adminUserHidden && adminUserDatalist) {
     let adminUserResults = [];
     let adminUserFetchController = null;
+    let lastConfirmedAdminUser = null;
 
-    function resetAdminSelection() {
+    if (adminUserHidden.value && adminUserInput.value.trim()) {
+      lastConfirmedAdminUser = {
+        id: adminUserHidden.value,
+        label: adminUserInput.value.trim(),
+      };
+    }
+
+    function clearAdminSelection() {
       adminUserHidden.value = '';
+      lastConfirmedAdminUser = null;
     }
 
     function updateAdminUserSuggestions(results) {
@@ -101,7 +110,7 @@
     function commitAdminSelection() {
       const value = adminUserInput.value.trim();
       if (!value) {
-        resetAdminSelection();
+        clearAdminSelection();
         return;
       }
       const normalized = value.toLowerCase();
@@ -109,10 +118,12 @@
         user && user.label && user.label.toLowerCase() === normalized,
       );
       if (match && match.id !== null && match.id !== undefined) {
-        adminUserHidden.value = String(match.id);
+        const confirmedId = String(match.id);
+        adminUserHidden.value = confirmedId;
         adminUserInput.value = match.label;
-      } else {
-        resetAdminSelection();
+        lastConfirmedAdminUser = { id: confirmedId, label: match.label };
+      } else if (!adminUserHidden.value && lastConfirmedAdminUser) {
+        adminUserHidden.value = String(lastConfirmedAdminUser.id);
       }
     }
 
@@ -148,7 +159,9 @@
       const term = event.target.value.trim();
       if (term.length < 2) {
         updateAdminUserSuggestions([]);
-        resetAdminSelection();
+        if (!term.length) {
+          clearAdminSelection();
+        }
         return;
       }
       fetchAdminUserSuggestions(term);
@@ -163,6 +176,12 @@
     if (adminForm) {
       adminForm.addEventListener('submit', () => {
         commitAdminSelection();
+        if (!adminUserHidden.value && lastConfirmedAdminUser) {
+          adminUserHidden.value = String(lastConfirmedAdminUser.id);
+          if (!adminUserInput.value.trim()) {
+            adminUserInput.value = lastConfirmedAdminUser.label;
+          }
+        }
       });
     }
   }


### PR DESCRIPTION
## Summary
- preserve the last confirmed admin user suggestion in the new request form and reuse it when submitting without a new choice
- add a backend fallback in `new_request` to resolve a single active user from the lookup when the hidden id is missing
- extend the request time tests with a regression case for the admin lookup fallback and adjust the ambiguity test

## Testing
- PYTHONPATH=. pytest tests/test_request_times.py

------
https://chatgpt.com/codex/tasks/task_e_68da95b635a48330bbfef895e37123db