### PR TITLE
Use vehicle code in approval email

### DIFF
--- a/app.py
+++ b/app.py
@@ -1231,7 +1231,7 @@ def manage_request(rid):
                             (
                                 f"Votre réservation du {r.start_at.strftime('%d/%m/%Y %H:%M')} au "
                                 f"{r.end_at.strftime('%d/%m/%Y %H:%M')} a été validée.\n"
-                                f"Véhicule attribué : {v.label}."
+                                f"Véhicule attribué : {v.code}."
                             ),
                             recipients,
                         )


### PR DESCRIPTION
## Summary
- replace the approval email vehicle reference to use the vehicle code instead of the label

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da9eaa1d7c833088c147322ea627df