### PR TITLE
Pass month parameters to monthly PDF export

### DIFF
--- a/templates/calendar_month.html
+++ b/templates/calendar_month.html
@@ -87,6 +87,6 @@
 </div>
 <p class="text-muted">Légende : <span class="badge bg-success">Nom du réservant (Matin/Après-midi/Journée)</span> = Réservé (approuvé)</p>
 {% if user and user.role in ['admin', 'superadmin'] %}
-  <a class="btn btn-outline-secondary" href="{{ url_for('export_pdf_month') }}">Exporter PDF du mois</a>
+  <a class="btn btn-outline-secondary" href="{{ url_for('export_pdf_month', y=start.year, m=start.month) }}">Exporter PDF du mois</a>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- ensure the calendar month export button sends the displayed year and month to the PDF endpoint

## Testing
- Manual: Navigated to a different month in the calendar UI and exported the PDF to confirm the file matches that month


------
https://chatgpt.com/codex/tasks/task_e_68daa0bd87fc8330b4183562d37fb4ad