### PR TITLE
Split PDF month layout into two rows

### DIFF
--- a/templates/pdf_month.html
+++ b/templates/pdf_month.html
@@ -1,44 +1,94 @@
-
 <!doctype html><html><head><meta charset="utf-8">
 <link href="https://cdn.jsdelivr.net/npm/bootswatch@5.3.2/dist/litera/bootstrap.min.css" rel="stylesheet">
 <link href="{{ url_for('static', filename='custom.css') }}" rel="stylesheet">
-<style>
-@page{size:A3 landscape;margin:8mm}
-body{font-family:sans-serif;font-size:10px}
-table{width:100%;border-collapse:collapse}th,td{border:1px solid #999;padding:2px 3px;vertical-align:top;text-align:center}
-th.sticky, td.sticky{position:sticky;left:0;background:#fff}
-</style></head><body>
-<h1>Planning véhicules — {{ month_year_label(start) }}</h1>
 {% set days = (end - start).days %}
+{% if days <= 28 %}
+    {% set font_size = 9 %}
+{% elif days <= 30 %}
+    {% set font_size = 8.5 %}
+{% elif days <= 31 %}
+    {% set font_size = 8 %}
+{% else %}
+    {% set font_size = 7.5 %}
+{% endif %}
+{% set split_index = (days + 1) // 2 %}
+{% set first_half = range(split_index) %}
+{% set second_half = range(split_index, days) %}
+{% set first_half_len = first_half|length %}
+{% set second_half_len = second_half|length %}
+{% set filler_count = first_half_len - second_half_len %}
+<style>
+@page{size:A3 landscape;margin:5mm}
+body{font-family:sans-serif;font-size:{{ font_size }}px}
+table{width:100%;border-collapse:collapse}
+th,td{border:1px solid #999;padding:1px 2px;vertical-align:top;text-align:center}
+th.sticky,td.sticky{position:sticky;left:0;background:#fff}
+.badge{padding:0.15rem 0.3rem;line-height:1.1;font-weight:600}
+.reservation-details{line-height:1.2;margin-top:1px}
+.vehicle-info{min-width:120px}
+.filler-cell{background:#f7f7f7}
+</style>
+{% macro render_day_cell(vehicle, day) %}
+<td>
+    {% for r in reservations if r.vehicle_id==vehicle.id and r.start_at.date() <= day.date() <= r.end_at.date() %}
+    <span class="badge text-bg-success">{{ slot_label(r, day) }}</span>
+    {% set full_name = (r.user.first_name or '') ~ (' ' if r.user.first_name and r.user.last_name else '') ~ (r.user.last_name or '') %}
+    {% if full_name|trim %}
+        {% set reserver_name = full_name|trim %}
+    {% else %}
+        {% set reserver_name = r.user.name %}
+    {% endif %}
+    {% set purpose = r.purpose|default('', true)|trim %}
+    {% if not purpose %}
+        {% set purpose = 'Motif non renseigné' %}
+    {% endif %}
+    <div class="small text-muted reservation-details">{{ reserver_name }} — {{ purpose }}</div>
+    {% endfor %}
+</td>
+{% endmacro %}
+</head><body>
+<h1>Planning véhicules — {{ month_year_label(start) }}</h1>
 <div class="table-responsive">
 <table>
 <thead>
-<tr><th class="sticky">Véhicule</th>
-{% for i in range(days) %}<th>{{ (start + timedelta(days=i)).strftime("%d") }}</th>{% endfor %}
-</tr></thead>
+<tr>
+    <th class="sticky" rowspan="2">Véhicule</th>
+    {% for i in first_half %}
+        {% set day = start + timedelta(days=i) %}
+        <th>{{ day.strftime("%d") }}</th>
+    {% endfor %}
+</tr>
+<tr>
+    {% for i in second_half %}
+        {% set day = start + timedelta(days=i) %}
+        <th>{{ day.strftime("%d") }}</th>
+    {% endfor %}
+    {% if filler_count > 0 %}
+        {% for _ in range(filler_count) %}
+            <th></th>
+        {% endfor %}
+    {% endif %}
+</tr>
+</thead>
 <tbody>
 {% for v in vehicles %}
-<tr>
-<td class="sticky"><strong>{{ v.code }}</strong><br>{{ v.label }}</td>
-{% for i in range(days) %}
-{% set day = start + timedelta(days=i) %}
-<td>
-{% for r in reservations if r.vehicle_id==v.id and r.start_at.date() <= day.date() <= r.end_at.date() %}
-<span class="badge text-bg-success">{{ slot_label(r, day) }}</span>
-{% set full_name = (r.user.first_name or '') ~ (' ' if r.user.first_name and r.user.last_name else '') ~ (r.user.last_name or '') %}
-{% if full_name|trim %}
-    {% set reserver_name = full_name|trim %}
-{% else %}
-    {% set reserver_name = r.user.name %}
-{% endif %}
-{% set purpose = r.purpose|default('', true)|trim %}
-{% if not purpose %}
-    {% set purpose = 'Motif non renseigné' %}
-{% endif %}
-<div class="small text-muted">{{ reserver_name }} — {{ purpose }}</div>
-{% endfor %}
-</td>
-{% endfor %}
+<tr class="vehicle-row vehicle-row--first">
+    <td class="sticky vehicle-info" rowspan="2"><strong>{{ v.code }}</strong><br>{{ v.label }}</td>
+    {% for i in first_half %}
+        {% set day = start + timedelta(days=i) %}
+        {{ render_day_cell(v, day) }}
+    {% endfor %}
+</tr>
+<tr class="vehicle-row vehicle-row--second">
+    {% for i in second_half %}
+        {% set day = start + timedelta(days=i) %}
+        {{ render_day_cell(v, day) }}
+    {% endfor %}
+    {% if filler_count > 0 %}
+        {% for _ in range(filler_count) %}
+            <td class="filler-cell"></td>
+        {% endfor %}
+    {% endif %}
 </tr>
 {% endfor %}
 </tbody>

--- a/tests/test_reservation_slots.py
+++ b/tests/test_reservation_slots.py
@@ -46,6 +46,9 @@ def test_same_day_reservations_have_distinct_slots():
     assert 'Bob (Après-midi)' in html
     assert 'Matin' in pdf_html
     assert 'Après-midi' in pdf_html
+    assert 'rowspan="2"' in pdf_html
+    assert 'vehicle-row--second' in pdf_html
+    assert 'class="filler-cell"' in pdf_html
 
 
 def test_partial_afternoon_reservation_is_labelled_afternoon():


### PR DESCRIPTION
## Summary
- split the PDF month header into two rows and mirror the vehicle rows to keep days aligned across halves
- tighten margins, font sizing, and badge spacing to fit the denser two-line layout
- extend the reservation slot rendering test to cover the new table structure

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcc42ee29c8330954084b7a2771b8f