### PR TITLE
Etendre la purge des réservations expirées

### DIFF
--- a/tests/test_reservation_purge.py
+++ b/tests/test_reservation_purge.py
@@ -45,3 +45,79 @@ def test_purge_expired_pending_reservations():
         assert Reservation.query.count() == 1
         assert Reservation.query.first().id == fresh_res.id
         db.drop_all()
+
+
+def test_purge_expired_non_pending_reservations():
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    app.config['TESTING'] = True
+    with app.app_context():
+        db.session.remove()
+        db.drop_all()
+        db.create_all()
+
+        user = User(
+            name='User',
+            first_name='Foo',
+            last_name='Bar',
+            email='u2@example.com',
+            role=User.ROLE_USER,
+            password_hash='x'
+        )
+        db.session.add(user)
+        db.session.commit()
+
+        now = datetime.utcnow()
+        very_old_end = now - timedelta(days=8)
+        recent_end = now - timedelta(days=6)
+
+        old_approved = Reservation(
+            user_id=user.id,
+            start_at=very_old_end - timedelta(hours=2),
+            end_at=very_old_end,
+            status='approved'
+        )
+        old_rejected = Reservation(
+            user_id=user.id,
+            start_at=very_old_end - timedelta(hours=3),
+            end_at=very_old_end - timedelta(minutes=30),
+            status='rejected'
+        )
+        recent_approved = Reservation(
+            user_id=user.id,
+            start_at=recent_end - timedelta(hours=1),
+            end_at=recent_end,
+            status='approved'
+        )
+        recent_rejected = Reservation(
+            user_id=user.id,
+            start_at=recent_end - timedelta(hours=1, minutes=30),
+            end_at=recent_end - timedelta(minutes=10),
+            status='rejected'
+        )
+        recent_pending = Reservation(
+            user_id=user.id,
+            start_at=now - timedelta(hours=2),
+            end_at=now - timedelta(hours=1),
+            status='pending'
+        )
+
+        db.session.add_all([
+            old_approved,
+            old_rejected,
+            recent_approved,
+            recent_rejected,
+            recent_pending,
+        ])
+        db.session.commit()
+
+        deleted = purge_expired_requests()
+
+        remaining_ids = {res.id for res in Reservation.query.all()}
+        assert deleted == 2
+        assert remaining_ids == {
+            recent_approved.id,
+            recent_rejected.id,
+            recent_pending.id,
+        }
+
+        db.drop_all()

--- a/tools/fin_de_journee.sh
+++ b/tools/fin_de_journee.sh
@@ -10,7 +10,7 @@ TS="$(date +%Y%m%d_%H%M%S)"
 echo "== Fin de journée - $DATE =="
 echo "Répertoire: $REPO"
 
-# Purge quotidienne des demandes de réservation expirées
+# Purge quotidienne des réservations expirées (en attente >2j, autres >7j)
 flask --app app purge-expired-requests >/dev/null 2>&1 || true
 
 # 1) Patch des changements non commités (inclut l'intention d'ajout des nouveaux fichiers)


### PR DESCRIPTION
## Summary
- élargir la fonction de purge pour supprimer les réservations en attente âgées de plus de deux jours et les autres statuts au-delà de sept jours
- ajuster la commande CLI, la documentation et le script de fin de journée pour refléter la nouvelle fenêtre de purge
- couvrir les cas approuvés/rejetés dans les tests afin de vérifier la suppression et la conservation des réservations selon leur statut et ancienneté

## Testing
- `PYTHONPATH=. pytest tests/test_reservation_purge.py`


------
https://chatgpt.com/codex/tasks/task_e_68e2408000308330a50b1399987a2bce