### PR TITLE
Prioritize pending admin reservations and highlight rows

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,7 +36,7 @@ from forms import (
 from wtforms.validators import DataRequired, Length
 from models import db, User, Vehicle, Reservation, ReservationSegment, NotificationSettings
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy import or_
+from sqlalchemy import or_, case
 from notify import send_mail_msmtp
 from flask_migrate import Migrate
 from utils import reservation_slot_label
@@ -1040,7 +1040,12 @@ def reservation_notification_recipients(reservation):
 def admin_reservations():
     user = current_user()
     res = (
-        Reservation.query.order_by(Reservation.start_at.desc()).limit(200).all()
+        Reservation.query.order_by(
+            case((Reservation.status == "pending", 0), else_=1),
+            Reservation.start_at.desc(),
+        )
+        .limit(200)
+        .all()
     )
     return render_template(
         "admin_reservations.html",

--- a/templates/admin_reservations.html
+++ b/templates/admin_reservations.html
@@ -8,7 +8,7 @@
     <thead><tr><th>ID</th><th>Véhicule</th><th>Début</th><th>Fin</th><th>Demandeur</th><th>Statut</th><th></th></tr></thead>
     <tbody>
     {% for r in reservations %}
-      <tr>
+      <tr class="{% if r.status == 'pending' %}table-warning{% endif %}">
         <td>{{ r.id }}</td>
         <td>{{ r.vehicle.code if r.vehicle else "A AFFECTER" }}</td>
         <td>{{ r.start_at.strftime('%d/%m/%Y') }} {{ slot_label(r, r.start_at) }}</td>


### PR DESCRIPTION
## Summary
- order admin reservation listing so pending requests appear first while preserving reverse chronological order
- highlight pending reservations in the admin table to make outstanding requests easy to spot

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e28560b36c8330a7a4257d871d0777