### PR TITLE
Reduce compact PDF layout width for long months

### DIFF
--- a/templates/pdf_month.html
+++ b/templates/pdf_month.html
@@ -16,18 +16,18 @@
 {% set second_half = range(first_half_limit, days) %}
 {% set compact_layout = second_half|length > 15 %}
 {% if compact_layout %}
-    {% set font_size = 7.2 %}
+    {% set font_size = 6.8 %}
 {% endif %}
 <style>
 @page{size:A3 landscape;margin:5mm}
 body{font-family:sans-serif;font-size:{{ font_size }}px}
 table{width:100%;border-collapse:collapse}
-th,td{border:1px solid #999;padding:{{ '0 1px' if compact_layout else '1px 2px' }};vertical-align:top;text-align:center}
+th,td{border:1px solid #999;padding:{{ '0 0.5px' if compact_layout else '1px 2px' }};vertical-align:top;text-align:center}
 th.sticky,td.sticky{position:sticky;left:0;background:#fff}
 .badge{padding:0.15rem 0.3rem;line-height:1.1;font-weight:600}
 .reservation-details{line-height:1.2;margin-top:1px}
-.vehicle-info{min-width:{{ '110px' if compact_layout else '120px' }}}
-.planning-table{margin-bottom:24px}
+.vehicle-info{min-width:{{ '95px' if compact_layout else '120px' }}}
+.planning-table{margin-bottom:24px;table-layout:fixed}
 .planning-table:last-of-type{margin-bottom:0}
 </style>
 {% macro render_day_cell(vehicle, day) %}


### PR DESCRIPTION
## Summary
- decrease the compact-layout font size and padding so late-month days fit more easily
- enforce a fixed planning-table layout and shrink the vehicle column when compact to avoid clipping

## Testing
- python - <<'PY'
from datetime import datetime, timedelta
from weasyprint import HTML
from flask import render_template
from app import app, reservation_slot_label

with app.app_context():
    with app.test_request_context():
        start = datetime(2024, 1, 1)
        end = datetime(2024, 2, 1)
        html = render_template(
            'pdf_month.html',
            vehicles=[],
            reservations=[],
            start=start,
            end=end,
            slot_label=reservation_slot_label,
            timedelta=timedelta,
        )
    HTML(string=html).write_pdf('planning_2024-01.pdf')
    print('PDF generated')
PY

------
https://chatgpt.com/codex/tasks/task_e_68e29051be808330b8b6ca068d62e52d